### PR TITLE
Add notebook-for-pc.ipynb: modular version of v1.ipynb for high-end local PCs

### DIFF
--- a/notebook-for-pc.ipynb
+++ b/notebook-for-pc.ipynb
@@ -1,0 +1,10817 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Kd0Hc_ItxPrz"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install torch torchvision torchaudio rdkit datasets tokenizers tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "#final_version\n",
+    "# stereochemistry_fixed\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.optim as optim\n",
+    "import torch.nn.functional as F\n",
+    "from torch.utils.data import Dataset, DataLoader\n",
+    "from torch_geometric.nn import MessagePassing, global_mean_pool\n",
+    "from torch_geometric.data import Data, Batch\n",
+    "from datasets import load_dataset\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from rdkit import Chem\n",
+    "from rdkit.Chem import Draw, Descriptors, rdFMCS, EnumerateStereoisomers\n",
+    "from rdkit import DataStructs\n",
+    "from rdkit.Chem import rdFingerprintGenerator\n",
+    "from tqdm import tqdm\n",
+    "import math\n",
+    "from sklearn.model_selection import KFold\n",
+    "import matplotlib.pyplot as plt\n",
+    "from torch.cuda.amp import GradScaler, autocast\n",
+    "import optuna\n",
+    "from nltk.translate.bleu_score import sentence_bleu\n",
+    "from Levenshtein import distance\n",
+    "from pandarallel import pandarallel #Added by Pawan\n",
+    "import time  #Added by Pawan\n",
+    "import os #Added by Pawan\n",
+    "import glob #Added by Pawan\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Set random seed for reproducibility\n",
+    "torch.manual_seed(42)\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "# Define token variables early\n",
+    "PAD_TOKEN = \"<PAD>\"\n",
+    "SOS_TOKEN = \"<SOS>\"\n",
+    "EOS_TOKEN = \"<EOS>\"\n",
+    "MASK_TOKEN = \"[MASK]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load and preprocess dataset\n",
+    "dataset = load_dataset('roman-bushuiev/MassSpecGym', split='val')\n",
+    "df = pd.DataFrame(dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MassSpecGym size: 207993 External test size: 23111\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Simulate external dataset (e.g., NIST-like) by splitting\n",
+    "df_massspecgym, df_external = df.iloc[:int(0.9*len(df))], df.iloc[int(0.9*len(df)):]\n",
+    "print(\"MassSpecGym size:\", len(df_massspecgym), \"External test size:\", len(df_external))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset Columns: ['identifier', 'mzs', 'intensities', 'smiles', 'inchikey', 'formula', 'precursor_formula', 'parent_mass', 'precursor_mz', 'adduct', 'instrument_type', 'collision_energy', 'fold', 'simulation_challenge']\n",
+      "\n",
+      "First few rows of MassSpecGym dataset:\n",
+      "             identifier                                                mzs  \\\n",
+      "0  MassSpecGymID0000001  91.0542,125.0233,154.0499,155.0577,185.0961,20...   \n",
+      "1  MassSpecGymID0000002  91.0542,125.0233,155.0577,185.0961,229.0859,24...   \n",
+      "2  MassSpecGymID0000003  69.0343,91.0542,125.0233,127.039,153.0699,154....   \n",
+      "3  MassSpecGymID0000004  69.0343,91.0542,110.06,111.0441,112.0393,120.0...   \n",
+      "4  MassSpecGymID0000005  91.0542,125.0233,185.0961,229.0859,246.1125,28...   \n",
+      "\n",
+      "                                         intensities  \\\n",
+      "0  0.24524524524524524,1.0,0.08008008008008008,0....   \n",
+      "1  0.0990990990990991,0.28128128128128127,0.04004...   \n",
+      "2  0.03403403403403404,0.31431431431431434,1.0,0....   \n",
+      "3  0.17917917917917917,0.47347347347347346,0.0380...   \n",
+      "4  0.07807807807807808,0.1841841841841842,0.03503...   \n",
+      "\n",
+      "                                          smiles  adduct  precursor_mz  \n",
+      "0  CC(=O)N[C@@H](CC1=CC=CC=C1)C2=CC(=CC(=O)O2)OC  [M+H]+      288.1225  \n",
+      "1  CC(=O)N[C@@H](CC1=CC=CC=C1)C2=CC(=CC(=O)O2)OC  [M+H]+      288.1225  \n",
+      "2  CC(=O)N[C@@H](CC1=CC=CC=C1)C2=CC(=CC(=O)O2)OC  [M+H]+      288.1225  \n",
+      "3  CC(=O)N[C@@H](CC1=CC=CC=C1)C2=CC(=CC(=O)O2)OC  [M+H]+      288.1225  \n",
+      "4  CC(=O)N[C@@H](CC1=CC=CC=C1)C2=CC(=CC(=O)O2)OC  [M+H]+      288.1225  \n",
+      "\n",
+      "Unique adduct values: ['[M+H]+' '[M+Na]+']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inspect dataset\n",
+    "print(\"Dataset Columns:\", df_massspecgym.columns.tolist())\n",
+    "print(\"\\nFirst few rows of MassSpecGym dataset:\")\n",
+    "print(df_massspecgym[['identifier', 'mzs', 'intensities', 'smiles', 'adduct', 'precursor_mz']].head())\n",
+    "print(\"\\nUnique adduct values:\", df_massspecgym['adduct'].unique())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "identifier \tmzs \tintensities \tinchikey \tformula \tprecursor_formula \tparent_mass \tprecursor_mz \tadduct \tinstrument_type \tcollision_energy \tfold \tsimulation_challenge \tsmiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Data augmentation: SMILES enumeration and spectral noise\n",
+    "def augment_smiles(smiles):\n",
+    "    try:\n",
+    "        mol = Chem.MolFromSmiles(smiles)\n",
+    "        if mol:\n",
+    "            stereoisomers = EnumerateStereoisomers.EnumerateStereoisomers(mol)\n",
+    "            return [Chem.MolToSmiles(m, canonical=True, doRandom=True) for m in stereoisomers]\n",
+    "        return [smiles]\n",
+    "    except:\n",
+    "        return [smiles]\n",
+    "\n",
+    "def bin_spectrum_to_graph(mzs, intensities, ion_mode, precursor_mz, adduct, n_bins=1000, max_mz=1000, noise_level=0.05):\n",
+    "    spectrum = np.zeros(n_bins)\n",
+    "    for mz, intensity in zip(mzs, intensities):\n",
+    "        try:\n",
+    "            mz = float(mz)\n",
+    "            intensity = float(intensity)\n",
+    "            if mz < max_mz:\n",
+    "                bin_idx = int((mz / max_mz) * n_bins)\n",
+    "                spectrum[bin_idx] += intensity\n",
+    "        except (ValueError, TypeError):\n",
+    "            continue\n",
+    "    if spectrum.max() > 0:\n",
+    "        spectrum = spectrum / spectrum.max()\n",
+    "    spectrum += np.random.normal(0, noise_level, spectrum.shape).clip(0, 1)\n",
+    "    x = torch.tensor(spectrum, dtype=torch.float).unsqueeze(-1)\n",
+    "    edge_index = []\n",
+    "    for i in range(n_bins-1):\n",
+    "        edge_index.append([i, i+1])\n",
+    "        edge_index.append([i+1, i])\n",
+    "    edge_index = torch.tensor(edge_index, dtype=torch.long).t()\n",
+    "    ion_mode = torch.tensor([ion_mode], dtype=torch.float)\n",
+    "    precursor_mz = torch.tensor([precursor_mz], dtype=torch.float)\n",
+    "    adduct_idx = adduct_to_idx.get(adduct, 0)\n",
+    "    return spectrum, Data(x=x, edge_index=edge_index, ion_mode=ion_mode, precursor_mz=precursor_mz, adduct_idx=adduct_idx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: Pandarallel will run on 16 workers.\n",
+      "INFO: Pandarallel will use Memory file system to transfer data between the main process and workers.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3309bec255e44288b3730771f238ae3b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=13000), Label(value='0 / 13000')))…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_1374468/1716703814.py:13: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  df_massspecgym['smiles'] = df_massspecgym['smiles'].parallel_apply(canonicalize_smiles) # Added by Pawan\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "51c7942926d0444cbe55a50328f12539",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=1445), Label(value='0 / 1445'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_1374468/1716703814.py:14: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  df_external['smiles'] = df_external['smiles'].parallel_apply(canonicalize_smiles) #Added by Pawan\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0cfa8fe719514f1686666bd08e688834",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=13000), Label(value='0 / 13000')))…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Completed in 1823.35 seconds\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Canonicalize SMILES and augment\n",
+    "pandarallel.initialize(nb_workers=16, progress_bar=True) #Added by Pawan\n",
+    "start_time = time.time()\n",
+    "def canonicalize_smiles(smiles):\n",
+    "    try:\n",
+    "        mol = Chem.MolFromSmiles(smiles, sanitize=True)\n",
+    "        if mol:\n",
+    "            return Chem.MolToSmiles(mol, canonical=True)\n",
+    "        return None\n",
+    "    except:\n",
+    "        return None\n",
+    "\n",
+    "df_massspecgym['smiles'] = df_massspecgym['smiles'].parallel_apply(canonicalize_smiles) # Added by Pawan\n",
+    "df_external['smiles'] = df_external['smiles'].parallel_apply(canonicalize_smiles) #Added by Pawan\n",
+    "df_massspecgym = df_massspecgym.dropna(subset=['smiles']) \n",
+    "df_external = df_external.dropna(subset=['smiles'])\n",
+    "df_massspecgym['smiles_list'] = df_massspecgym['smiles'].parallel_apply(augment_smiles)\n",
+    "df_massspecgym = df_massspecgym.explode('smiles_list').dropna(subset=['smiles_list'])\n",
+    "df_massspecgym = df_massspecgym.drop(columns=['smiles']) # Drop original 'smiles' to prevent duplicates; added by Pawan\n",
+    "df_massspecgym = df_massspecgym.rename(columns={'smiles_list': 'smiles'}) # Rename exploded list column to 'smiles'; added by Pawan\n",
+    "df_massspecgym.to_parquet(\"df_massspecgym.parquet\")\n",
+    "df_external.to_parquet(\"df_external.parquet\")\n",
+    "print(\"Completed in {:.2f} seconds\".format(time.time() - start_time)) #Added by Pawan\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(19329189, 14)\n",
+      "207993\n",
+      "(23111, 14)\n",
+      "23111\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(df_massspecgym.shape) #Added by Pawan\n",
+    "print(df_massspecgym.index.nunique()) #Added by Pawan\n",
+    "print(df_external.shape) #Added by Pawan\n",
+    "print(df_external.index.nunique()) #Added by Pawan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_massspecgym.reset_index(drop=True, inplace=True) #Added by Pawan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(19329189, 14)\n",
+      "19329189\n",
+      "(23111, 14)\n",
+      "23111\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(df_massspecgym.shape) #Added by Pawan\n",
+    "print(df_massspecgym.index.nunique()) #Added by Pawan\n",
+    "print(df_external.shape) #Added by Pawan\n",
+    "print(df_external.index.nunique()) #Added by Pawan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>identifier</th>\n",
+       "      <th>mzs</th>\n",
+       "      <th>intensities</th>\n",
+       "      <th>inchikey</th>\n",
+       "      <th>formula</th>\n",
+       "      <th>precursor_formula</th>\n",
+       "      <th>parent_mass</th>\n",
+       "      <th>precursor_mz</th>\n",
+       "      <th>adduct</th>\n",
+       "      <th>instrument_type</th>\n",
+       "      <th>collision_energy</th>\n",
+       "      <th>fold</th>\n",
+       "      <th>simulation_challenge</th>\n",
+       "      <th>smiles</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MassSpecGymID0000001</td>\n",
+       "      <td>91.0542,125.0233,154.0499,155.0577,185.0961,20...</td>\n",
+       "      <td>0.24524524524524524,1.0,0.08008008008008008,0....</td>\n",
+       "      <td>VFMQMACUYWGDOJ</td>\n",
+       "      <td>C16H17NO4</td>\n",
+       "      <td>C16H18NO4</td>\n",
+       "      <td>287.115224</td>\n",
+       "      <td>288.1225</td>\n",
+       "      <td>[M+H]+</td>\n",
+       "      <td>Orbitrap</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>train</td>\n",
+       "      <td>True</td>\n",
+       "      <td>COc1cc(oc(c1)=O)[C@@H](NC(C)=O)Cc1ccccc1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>MassSpecGymID0000002</td>\n",
+       "      <td>91.0542,125.0233,155.0577,185.0961,229.0859,24...</td>\n",
+       "      <td>0.0990990990990991,0.28128128128128127,0.04004...</td>\n",
+       "      <td>VFMQMACUYWGDOJ</td>\n",
+       "      <td>C16H17NO4</td>\n",
+       "      <td>C16H18NO4</td>\n",
+       "      <td>287.115224</td>\n",
+       "      <td>288.1225</td>\n",
+       "      <td>[M+H]+</td>\n",
+       "      <td>Orbitrap</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>train</td>\n",
+       "      <td>True</td>\n",
+       "      <td>c1ccc(C[C@H](NC(=O)C)c2cc(cc(=O)o2)OC)cc1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>MassSpecGymID0000003</td>\n",
+       "      <td>69.0343,91.0542,125.0233,127.039,153.0699,154....</td>\n",
+       "      <td>0.03403403403403404,0.31431431431431434,1.0,0....</td>\n",
+       "      <td>VFMQMACUYWGDOJ</td>\n",
+       "      <td>C16H17NO4</td>\n",
+       "      <td>C16H18NO4</td>\n",
+       "      <td>287.115224</td>\n",
+       "      <td>288.1225</td>\n",
+       "      <td>[M+H]+</td>\n",
+       "      <td>Orbitrap</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>train</td>\n",
+       "      <td>True</td>\n",
+       "      <td>c1cccc(c1)C[C@@H](c1cc(cc(o1)=O)OC)NC(C)=O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>MassSpecGymID0000004</td>\n",
+       "      <td>69.0343,91.0542,110.06,111.0441,112.0393,120.0...</td>\n",
+       "      <td>0.17917917917917917,0.47347347347347346,0.0380...</td>\n",
+       "      <td>VFMQMACUYWGDOJ</td>\n",
+       "      <td>C16H17NO4</td>\n",
+       "      <td>C16H18NO4</td>\n",
+       "      <td>287.115224</td>\n",
+       "      <td>288.1225</td>\n",
+       "      <td>[M+H]+</td>\n",
+       "      <td>Orbitrap</td>\n",
+       "      <td>55.0</td>\n",
+       "      <td>train</td>\n",
+       "      <td>True</td>\n",
+       "      <td>c1cc(ccc1)C[C@@H](c1oc(=O)cc(OC)c1)NC(=O)C</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>MassSpecGymID0000005</td>\n",
+       "      <td>91.0542,125.0233,185.0961,229.0859,246.1125,28...</td>\n",
+       "      <td>0.07807807807807808,0.1841841841841842,0.03503...</td>\n",
+       "      <td>VFMQMACUYWGDOJ</td>\n",
+       "      <td>C16H17NO4</td>\n",
+       "      <td>C16H18NO4</td>\n",
+       "      <td>287.115224</td>\n",
+       "      <td>288.1225</td>\n",
+       "      <td>[M+H]+</td>\n",
+       "      <td>Orbitrap</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>train</td>\n",
+       "      <td>True</td>\n",
+       "      <td>N([C@H](c1oc(cc(OC)c1)=O)Cc1ccccc1)C(C)=O</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             identifier                                                mzs  \\\n",
+       "0  MassSpecGymID0000001  91.0542,125.0233,154.0499,155.0577,185.0961,20...   \n",
+       "1  MassSpecGymID0000002  91.0542,125.0233,155.0577,185.0961,229.0859,24...   \n",
+       "2  MassSpecGymID0000003  69.0343,91.0542,125.0233,127.039,153.0699,154....   \n",
+       "3  MassSpecGymID0000004  69.0343,91.0542,110.06,111.0441,112.0393,120.0...   \n",
+       "4  MassSpecGymID0000005  91.0542,125.0233,185.0961,229.0859,246.1125,28...   \n",
+       "\n",
+       "                                         intensities        inchikey  \\\n",
+       "0  0.24524524524524524,1.0,0.08008008008008008,0....  VFMQMACUYWGDOJ   \n",
+       "1  0.0990990990990991,0.28128128128128127,0.04004...  VFMQMACUYWGDOJ   \n",
+       "2  0.03403403403403404,0.31431431431431434,1.0,0....  VFMQMACUYWGDOJ   \n",
+       "3  0.17917917917917917,0.47347347347347346,0.0380...  VFMQMACUYWGDOJ   \n",
+       "4  0.07807807807807808,0.1841841841841842,0.03503...  VFMQMACUYWGDOJ   \n",
+       "\n",
+       "     formula precursor_formula  parent_mass  precursor_mz  adduct  \\\n",
+       "0  C16H17NO4         C16H18NO4   287.115224      288.1225  [M+H]+   \n",
+       "1  C16H17NO4         C16H18NO4   287.115224      288.1225  [M+H]+   \n",
+       "2  C16H17NO4         C16H18NO4   287.115224      288.1225  [M+H]+   \n",
+       "3  C16H17NO4         C16H18NO4   287.115224      288.1225  [M+H]+   \n",
+       "4  C16H17NO4         C16H18NO4   287.115224      288.1225  [M+H]+   \n",
+       "\n",
+       "  instrument_type  collision_energy   fold  simulation_challenge  \\\n",
+       "0        Orbitrap              30.0  train                  True   \n",
+       "1        Orbitrap              20.0  train                  True   \n",
+       "2        Orbitrap              40.0  train                  True   \n",
+       "3        Orbitrap              55.0  train                  True   \n",
+       "4        Orbitrap              10.0  train                  True   \n",
+       "\n",
+       "                                       smiles  \n",
+       "0    COc1cc(oc(c1)=O)[C@@H](NC(C)=O)Cc1ccccc1  \n",
+       "1   c1ccc(C[C@H](NC(=O)C)c2cc(cc(=O)o2)OC)cc1  \n",
+       "2  c1cccc(c1)C[C@@H](c1cc(cc(o1)=O)OC)NC(C)=O  \n",
+       "3  c1cc(ccc1)C[C@@H](c1oc(=O)cc(OC)c1)NC(=O)C  \n",
+       "4   N([C@H](c1oc(cc(OC)c1)=O)Cc1ccccc1)C(C)=O  "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_massspecgym.head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#Preprocess ion mode, precursor m/z, and adducts\n",
+    "from pandarallel import pandarallel #Added by Pawan\n",
+    "pandarallel.initialize(nb_workers=16, progress_bar=True) #Added by Pawan\n",
+    "import time # Added by Pawan\n",
+    "start_time = time.time()\n",
+    "df_massspecgym['ion_mode'] = df_massspecgym['adduct'].parallel_apply(lambda x: 0 if '+' in str(x) else 1 if '-' in str(x) else 0).fillna(0)\n",
+    "df_massspecgym['precursor_bin'] = pd.qcut(df_massspecgym['precursor_mz'], q=100, labels=False, duplicates='drop')\n",
+    "df_external['ion_mode'] = df_external['adduct'].parallel_apply(lambda x: 0 if '+' in str(x) else 1 if '-' in str(x) else 0).fillna(0)\n",
+    "df_external['precursor_bin'] = pd.qcut(df_external['precursor_mz'], q=100, labels=False, duplicates='drop')\n",
+    "adduct_types = df_massspecgym['adduct'].unique()\n",
+    "adduct_to_idx = {adduct: i for i, adduct in enumerate(adduct_types)}\n",
+    "df_massspecgym['adduct_idx'] = df_massspecgym['adduct'].map(adduct_to_idx)\n",
+    "df_external['adduct_idx'] = df_external['adduct'].map(adduct_to_idx)\n",
+    "\n",
+    "df_massspecgym[['binned', 'graph_data']] = df_massspecgym.parallel_apply(\n",
+    "    lambda row: pd.Series(bin_spectrum_to_graph(row['mzs'], row['intensities'], row['ion_mode'], row['precursor_mz'], row['adduct'])),\n",
+    "    axis=1\n",
+    ")\n",
+    "df_external[['binned', 'graph_data']] = df_external.parallel_apply(\n",
+    "    lambda row: pd.Series(bin_spectrum_to_graph(row['mzs'], row['intensities'], row['ion_mode'], row['precursor_mz'], row['adduct'])),\n",
+    "    axis=1\n",
+    ")\n",
+    "print(\"Completed in {:.2f} seconds\".format(time.time() - start_time)) #Added by Pawan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: Pandarallel will run on 16 workers.\n",
+      "INFO: Pandarallel will use Memory file system to transfer data between the main process and workers.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Preprocess ion mode, precursor m/z, and adducts\n",
+    "#Setup and Load\n",
+    "import os\n",
+    "import time\n",
+    "import pandas as pd\n",
+    "from pandarallel import pandarallel\n",
+    "import pyarrow as pa\n",
+    "\n",
+    "pandarallel.initialize(nb_workers=16, progress_bar=True)\n",
+    "\n",
+    "# Load datasets\n",
+    "df_massspecgym = pd.read_parquet(\"df_massspecgym.parquet\")\n",
+    "df_external = pd.read_parquet(\"df_external.parquet\")\n",
+    "\n",
+    "# Build adduct mapping from df_massspecgym\n",
+    "adduct_types = df_massspecgym['adduct'].unique()\n",
+    "adduct_to_idx = {adduct: i for i, adduct in enumerate(adduct_types)}\n",
+    "\n",
+    "# Create output directory\n",
+    "os.makedirs(\"processed_chunks\", exist_ok=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Preprocess ion mode, precursor m/z, and adducts\n",
+    "#Define Processing Function\n",
+    "def preprocess_chunk(df_chunk, chunk_idx):\n",
+    "    start_time = time.time()\n",
+    "\n",
+    "    df_chunk['ion_mode'] = df_chunk['adduct'].parallel_apply(\n",
+    "        lambda x: 0 if '+' in str(x) else 1 if '-' in str(x) else 0\n",
+    "    ).fillna(0)\n",
+    "\n",
+    "    df_chunk['precursor_bin'] = pd.qcut(\n",
+    "        df_chunk['precursor_mz'], q=100, labels=False, duplicates='drop'\n",
+    "    )\n",
+    "\n",
+    "    df_chunk['adduct_idx'] = df_chunk['adduct'].map(adduct_to_idx)\n",
+    "\n",
+    "    df_chunk[['binned', 'graph_data']] = df_chunk.parallel_apply(\n",
+    "        lambda row: pd.Series(bin_spectrum_to_graph(\n",
+    "            row['mzs'], row['intensities'], row['ion_mode'],\n",
+    "            row['precursor_mz'], row['adduct']\n",
+    "        )),\n",
+    "        axis=1\n",
+    "    )\n",
+    "\n",
+    "    # Drop graph_data column before saving to avoid pyarrow error\n",
+    "    df_chunk.drop(columns=['graph_data'], inplace=True)\n",
+    "\n",
+    "    df_chunk.to_parquet(f\"processed_chunks/df_massspecgym_chunk_{chunk_idx:03}.parquet\")\n",
+    "    print(f\"✅ Saved chunk {chunk_idx} | Rows: {len(df_chunk)} | Time: {time.time() - start_time:.2f} sec\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a8f2d22972ad485ebfcd4967bd7416cd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c34ea2e8b41d4235b1f7f3b74913cbb6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 0 | Rows: 100000 | Time: 52.61 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1581cecac9a845cbada90b830467fb93",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e8f14b623aff4196bbff24af24906f5d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 1 | Rows: 100000 | Time: 64.91 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d4c97cb5456645b9ac685b7b26cd80e6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "887e63f58ab7462e9323cf31bfb3d0b9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 2 | Rows: 100000 | Time: 55.39 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fb2a2fbfff3b42598e517146c9760627",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "061e2fe079c5442baa23e02ac4b4c541",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 3 | Rows: 100000 | Time: 54.43 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "21f9c3e5c1c94234b3cfa0bd595c32fd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c08f64b138f04ee889b755913abc98a0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 4 | Rows: 100000 | Time: 56.63 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "20152956ca02479a80b7a7bed8587b33",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b86a15146626447d8422c03f5b8ab92c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 5 | Rows: 100000 | Time: 56.80 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "39cb113b09c44ab197db353ec1834f08",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "93d1a271b46b450d90c6a4c42e48e72b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 6 | Rows: 100000 | Time: 55.22 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "be54aeecbb9e4b8fab10c20d1408a1e7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d2d29e1b9b1641d6965dd10acaa02dbc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 7 | Rows: 100000 | Time: 55.11 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6e85e66834144e62846d2e5e8b96bd6d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7596fb4d9dce46ef90b0277ebff5af14",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 8 | Rows: 100000 | Time: 54.97 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "65df5348355f4ad6add7452a732556fe",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "472b6822354d48a8af3d0c7ed998c1f2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 9 | Rows: 100000 | Time: 53.41 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a0529f0dad154e34b5667ed4f4262830",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ce29834e2e4b40c3913b394079aae7f6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 10 | Rows: 100000 | Time: 53.27 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d3aaeba41e1d42a7ad5d189c5647a82f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f57f4f2c6f3b490aa8d0cbb12b8b4f3f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 11 | Rows: 100000 | Time: 53.84 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1b5a5edea6924ef5bb609235b9009113",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1ceafddeb5e041f1bec1712f297555e0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 12 | Rows: 100000 | Time: 53.49 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ad88d263cdd849e6a19e329e5d267b47",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e7d253e7033e4c6b99b501680c9204d3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 13 | Rows: 100000 | Time: 53.63 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1b5d687a06dc41c1b4ae4b9787910d37",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5aa8ee3503ac48d5bc2482ee82014a50",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 14 | Rows: 100000 | Time: 55.54 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1dce87dee23a4b279fa38d74356bdccb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a9c0ddec7de341e0af7b6cadaab0b84e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 15 | Rows: 100000 | Time: 53.54 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "da3ee05c7b7c4439a4728600b7fa4767",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fc2f915479534da4a319a371d68402f2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 16 | Rows: 100000 | Time: 53.66 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cbe4ba5c1d1a4d4d9780652e13771a4d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2ef432661af04efdaa42880389324627",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 17 | Rows: 100000 | Time: 55.17 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ff384c2bf8d343569f9d3e4d6fb707e4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "160e562af6f14da2a8fb8e19d8c94ab5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 18 | Rows: 100000 | Time: 54.15 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d3907ee5d9b14edbb851fb818934a36e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b2bfc5e9eec34e238c5ff64742d39623",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 19 | Rows: 100000 | Time: 54.73 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cd531be8991e4a42a33c9937ae727e21",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a731c5bdf46a418eaf0562f2e0c3beea",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 20 | Rows: 100000 | Time: 56.42 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b43868162e6347fe8f820c74c15d8b58",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ba30b3149c7f48638edea592960c603e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 21 | Rows: 100000 | Time: 54.24 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c8deb636d5c0474588086cae77f1d05b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "45aa189d3c8349adb7396e6046058c06",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 22 | Rows: 100000 | Time: 54.60 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4994af4bfade468f829554d81bf4d15b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7fc9307eaf854cf1b2cb57c808d61241",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 23 | Rows: 100000 | Time: 53.51 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "31a39e94a9994eb1847d1e38802e9248",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3a1143d5bb4e44b6aaa981d5a58b7351",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 24 | Rows: 100000 | Time: 52.96 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "727114ae2e1c4a3e95ea8ca65f29c31e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0088ca7a5b2947b295ca7c486b4c7017",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 25 | Rows: 100000 | Time: 54.11 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bd3255a4da6b4532bf2b9860854b801b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5e66024dfdeb4d56908c28c08f293709",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 26 | Rows: 100000 | Time: 54.78 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a42e9cf79381443f904802c1d9a139fc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "40d0b23c075a40ab87c2f96d173c2a86",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 27 | Rows: 100000 | Time: 53.36 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cc72505e0dd74985a3aeb5db5ac140d4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "701de44fb0d243369b6dd3ee8d71206b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 28 | Rows: 100000 | Time: 53.02 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "18046bf222bd47b5ad99bb72e45e7e00",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b029fe7b880549249903ad1d5a783e42",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 29 | Rows: 100000 | Time: 53.29 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "17cacf025f054e04a2a10195a4138f54",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "870d2c525ebf461db52868711db8897f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 30 | Rows: 100000 | Time: 53.08 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cd3c42aa9d2f48e2b39ef46907e22408",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c39016788815474fb2bd1c53c7f0a6af",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 31 | Rows: 100000 | Time: 53.84 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "48cb0227284442b4b486b3a189b6f950",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8aacf3ff59524451ae10d28d3393fcf5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 32 | Rows: 100000 | Time: 53.15 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8ea5cc039c9e40a8873f932e6031de85",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aa6b2ee339444fc4a9e40573afd51412",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 33 | Rows: 100000 | Time: 53.13 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "be80bfc11af54b10af9816dc0fb8830c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "313c1aa0ebcc4e1f91b97cdd4c4f6012",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 34 | Rows: 100000 | Time: 56.98 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "58fea6554c9748afacc53ebf17af8a36",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d9abb768d3684e1bb2b6e312eef19541",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 35 | Rows: 100000 | Time: 56.03 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c516b643da354d48a0db8901031dd612",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "23c067f98c174c7c9056d0df6ae80af8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 36 | Rows: 100000 | Time: 54.57 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7eb1f1f1f2f64081ad8f81a9a1dedd08",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5b90c0cf7f91466284542cdf3bc55ad2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 37 | Rows: 100000 | Time: 53.01 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df9aec0efdc5482a96f5c2863c764867",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c9a0f475d3cb430682c2c59d27b159e5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 38 | Rows: 100000 | Time: 57.84 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f33c0ff427af4c4cb6ae76f9d32d1002",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c424b90214f548fbb11a440914f8a690",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 39 | Rows: 100000 | Time: 55.42 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a52314c9b7c2438485199852c04b6bce",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c15a1a1b366d4db1a2bb147054b1083d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 40 | Rows: 100000 | Time: 55.70 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "356268aaf30749ca9bc5e64f83181a75",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "492c4b60b586496296c89ad45535ab01",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 41 | Rows: 100000 | Time: 57.48 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3acde04ddc7e4244881e42143d967d01",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f65e4bbaa2e94f7f9f42af984c4b6bab",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 42 | Rows: 100000 | Time: 58.72 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bf9629fa6da74ed1a8907fad8fbd8ba7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eea6679e96214156837c92c0b0565205",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 43 | Rows: 100000 | Time: 57.97 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ee7a403e2644436a9bffbbec0962a627",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7bc23c6f1209476c94b34b1fd36ca352",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 44 | Rows: 100000 | Time: 59.25 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e6e9e36eefb74c0eb680ec87af5e0281",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "43b775c4aca346a2877872f2837346b6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 45 | Rows: 100000 | Time: 59.27 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "15832eb4988d40bfb79989566538427f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d55d8be264a1420195214389ffcab38e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 46 | Rows: 100000 | Time: 58.32 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5b6d366494c74c6f8162d9fa6a72bfb6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c654a6b5e46843229bde65c51df6c47d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 47 | Rows: 100000 | Time: 53.31 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f62b70e8a51b4695ae9b99f7183ac47a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ca5fe5846bf6404494b0dda5f7d2b534",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 48 | Rows: 100000 | Time: 55.91 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6e9f23b400d04133a28f7cb712a570f0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9afae40162414ad9a67265c662b39565",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 49 | Rows: 100000 | Time: 57.57 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4f1dedf4a0c54a078522f89d56a7d8a0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "461cd62a661a44c89e8a2b68c633748a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 50 | Rows: 100000 | Time: 56.63 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e4a6874d8462409daa65ffad8c874ed8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7652bbf7a67a4fbdb16528370e6e4327",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 51 | Rows: 100000 | Time: 58.24 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "28a158ba98a04fc29637005074e1e18a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ccf6983d363b441ca753b493ac41c24a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 52 | Rows: 100000 | Time: 58.92 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "57effbf3847a4722ac77fe3a56548551",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "03999c71b7dc4c6c8d6649de85e9712b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 53 | Rows: 100000 | Time: 57.24 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "54141516fe0e4ca7a657edb54b143bbd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e85c96dfd5ab446d87cabefb81b38643",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 54 | Rows: 100000 | Time: 57.62 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0c43a42ca486430e9494432638e0c8a9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "58f838d3e0e3412086876f7fc1907282",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 55 | Rows: 100000 | Time: 59.16 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ea1644cf08214c3c8af9f95dbe464c05",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a03b6f13d0ff4aa5a64d51ce2833f8e7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 56 | Rows: 100000 | Time: 57.05 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5054995934884ce4b5a49fbe6943261e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4006084eb9444880a6aee650aa2f3e57",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 57 | Rows: 100000 | Time: 58.11 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "44f5dfc5d0c942fd865976370326b703",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "effd3380d67543a6a7d3a34a51027146",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 58 | Rows: 100000 | Time: 60.19 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2fe41113bfc9407ab9261777b5b4196e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "82861f10a6274e589117667e25dc9aa0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 59 | Rows: 100000 | Time: 59.55 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a5fd1658e10f4dda9d8939eee3808c0c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd77529eb8614bd282113a213dc0a824",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 60 | Rows: 100000 | Time: 55.67 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b78de70f11ee4f5cbb162949474c1ea9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "560c3afc11df4c1aab945092fd45c4b6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 61 | Rows: 100000 | Time: 57.70 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2f33cbdf860041b0a33bd69f25c4c787",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5d9de937f45a4d9fa32a8e34c657f540",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 62 | Rows: 100000 | Time: 57.26 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "219627477ed541b99aec9190e3195875",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9ee923b88bda4f2599682538436aa667",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 63 | Rows: 100000 | Time: 58.27 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "732a1abe6e22443a98404d6357976ed4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ffa56cfa701a4d00ad10f9b0c1e4dee3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 64 | Rows: 100000 | Time: 55.41 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9c43b25117c44a42a61723d755cb8cbb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e54daa4a63c40a987948f44cf68c4fa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 65 | Rows: 100000 | Time: 54.48 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c62cb5db4b784d22a1b43c9a5fc66d37",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5040dd2c04074a8699d98cd94d1c8918",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 66 | Rows: 100000 | Time: 53.52 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "928bc7db524c4189bc99691dfc775e0b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4b8210961f8143748920ec8a2a2aa78a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 67 | Rows: 100000 | Time: 54.81 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5ec797b4e7f748ca98e0694e383e0cb3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "34bc1ec66c5243f8b698ace359e0f52d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 68 | Rows: 100000 | Time: 53.88 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2e63bc9be5074013ba627a69e0f67be8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "93b88d83211547b39067fc7d12a2f42e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 69 | Rows: 100000 | Time: 54.76 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "abaf7150a74d4e31bf76331934da9e31",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f0e9dd07eb7642208af7f6a7da4850fa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 70 | Rows: 100000 | Time: 54.96 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7b9ab824c089466789051d9dd4827c47",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9c2c8aeeef844568b7d262fe1c19b0e5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 71 | Rows: 100000 | Time: 55.29 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c342e889bded444abfae94e6e2303da9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e28c29d654d543deb299ba5aada35784",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 72 | Rows: 100000 | Time: 54.90 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9a9835ec02d04e93b4033b637d5d475d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2c9a68f4ba1048c2816211fb23fa79a8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 73 | Rows: 100000 | Time: 55.23 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a4e054c92f3b4d66b9d1035ea376914b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "22c336039a4f4bd7be9fa4eaf602205a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 74 | Rows: 100000 | Time: 55.60 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8bd547a72ca84142afbfb3ebf26f12ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "687fd0df6e144b43a97666fca2d85911",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 75 | Rows: 100000 | Time: 53.83 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a5a9d6f094334744b68d9e1372478377",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bcccca982b454ce98e3513e8e570c61e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 76 | Rows: 100000 | Time: 54.99 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ffe1f8b28cd3472f9e22aaf923e567c1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "43cace01978c4d5d8674da63608d0f13",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 77 | Rows: 100000 | Time: 54.22 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ded829b31db44382b35f8f0a9caa3d0a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "961bb61f8c8d4666b4aec513ba2b8766",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 78 | Rows: 100000 | Time: 54.21 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5c81dfcabe2f40b19fd6a95209d03944",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "46a2335ba33842c899ff1d6a1531a466",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 79 | Rows: 100000 | Time: 53.47 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "59476b2e9f45436ea477bfe066db5a1f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3903a47fbcd84fe993e999a9ee3f8a79",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 80 | Rows: 100000 | Time: 54.33 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a0bedb0d59604597b3aee2ce51982968",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5b5f723a03ff4ec3b99e5e035ceec1c8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 81 | Rows: 100000 | Time: 54.28 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "61acd62e0fd548ec867195ec0a8f7fb2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "846d849520264e6db2508455adec903f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 82 | Rows: 100000 | Time: 54.08 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "89e7f2838b63400e8373ee779f7adce0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7d60f7d028d641948bc32704576be6a1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 83 | Rows: 100000 | Time: 55.78 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e91c410694434465b0ea54efdd09df4d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2b0d173a01ab44c5bc947ea7f7a1f44c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 84 | Rows: 100000 | Time: 53.51 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2a1f7bf0533647a2aa3b5cd12602fa61",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8a0ea76212f54b3ea69bfbe84510a640",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 85 | Rows: 100000 | Time: 55.01 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fbf002502090462d943a05018921ea3a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9a3c9e3bfe8b441f8cb1a110d0f5b139",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 86 | Rows: 100000 | Time: 55.19 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4bcd6886f36b483c8d784053fd9089f7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a9ffb15abc1145abae8bf3ef7bcca10f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 87 | Rows: 100000 | Time: 54.78 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "43bb6d73f3f144b783de3903adafef44",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "516c67ccde5949cab09f62a24f4391b3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 88 | Rows: 100000 | Time: 53.62 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6fd5a1a4ae6e4fca85bd008f03f8077f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cc7c0bc4c7d441d28bd971d899754b3b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 89 | Rows: 100000 | Time: 55.40 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4927e0247c034bbb88c37748eedc2c76",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3de3ac9b751043a593a16b0e54682121",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 90 | Rows: 100000 | Time: 54.04 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f38ef0ef3dd34914a6078f6985f64b2e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "21674cd2b94a4a6a83288739fd4c9e48",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 91 | Rows: 100000 | Time: 56.18 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d2cb780c7434421bbed580343e3ecf6e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "45312bb27a5c478fbd92d132c97a8550",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 92 | Rows: 100000 | Time: 55.13 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "98c633d1cbfd44de82e1c27400bbcf00",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d846b517028a418ea696b5562ad3a97c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 93 | Rows: 100000 | Time: 55.88 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d6c7af14801e4051af705744b3dec4a3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "636425ee336e48309603c74dd70d868c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 94 | Rows: 100000 | Time: 55.27 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b494495acf5a4195af29164c366637f4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1db606a7d2f84038a73900132337bd72",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 95 | Rows: 100000 | Time: 55.54 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "278dee4c33c44ad08be85592536cb361",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "30c5049e1ec245cc8e1baae49a103a43",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 96 | Rows: 100000 | Time: 54.58 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a442c16975a146e3bd8e899aec48a1a7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e449826de02a409381011bbe870ec6ef",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 97 | Rows: 100000 | Time: 53.99 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6b29b5a3d89748ff9ff7544e29d5d72b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "edde7b92ef6547e6b37d391df802d6b6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 98 | Rows: 100000 | Time: 55.62 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "36931dd8548a40018c69940debcda061",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a5fbf81cd7e4eeda64a03ac8af075f1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 99 | Rows: 100000 | Time: 53.97 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1cdd710025304a51904d1854bb0db546",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ba9c39519d544f649cc3cdead81d83eb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 100 | Rows: 100000 | Time: 55.82 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "19446302e2e643a7b315da6baed62258",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4a97dec7dd9a4483a8256b6ab0a980f7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 101 | Rows: 100000 | Time: 53.20 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a0a791b73d1a451a884ffbbeb3944e58",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5638a1acb52847669b5d0ef63625c461",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 102 | Rows: 100000 | Time: 56.08 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d92b3df555f24fc8a7daaa93016273ac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8d1a34f050bb4d61a9d8d724e27064f3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 103 | Rows: 100000 | Time: 55.22 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0784bb7c4a7d43c1966b779c1e73180d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2ede7940bd384dfe96edc507c7054103",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 104 | Rows: 100000 | Time: 55.63 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2c6a57054452489b967ece5d5f5ef6c0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5bee83637fa742a8933babe80c771c96",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 105 | Rows: 100000 | Time: 54.24 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "16153cfc2dea4073a6d2994d7cac10e4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "53e72540d8cf4b188725da9fb9a4407d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 106 | Rows: 100000 | Time: 55.91 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "51aff3cd8b55439887dbf012e9244736",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e3a1cc2af4594a87ad94dbdee189ddaf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 107 | Rows: 100000 | Time: 55.11 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5582ed879a3341358a384573ded29506",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4a7f1065669447e68e0fd261cd44adb0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 108 | Rows: 100000 | Time: 54.94 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "87e32093dece4671b79382180f161942",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "441046d433b64e71aa5822f700e8df3b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 109 | Rows: 100000 | Time: 54.34 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9e4e3f6a9be0464286987e614d275e2e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f2546c51e134427c882ec83dd4e61cdb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 110 | Rows: 100000 | Time: 54.43 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "baf5305089c14244a3a320945fab3aa5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3ae35781797b410bbfc859c14c78ab8d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 111 | Rows: 100000 | Time: 55.51 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f2e905d075664e0e8853202fda73e648",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c016141285cd4bd3a9f4164f46b448e5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 112 | Rows: 100000 | Time: 54.67 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "01f2da82eac74099a4bebb1d308d692f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e9198a609f8e4236bf709b3728b659c3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 113 | Rows: 100000 | Time: 54.32 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fdd8b311af1046528436306884ed0363",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c83ff28feb7941d3800869c2029bd036",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 114 | Rows: 100000 | Time: 55.08 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3ea698792e36443da666ac15ab45a256",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "87c82c15a1bd4589bc57391e30098f02",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 115 | Rows: 100000 | Time: 54.82 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3619d6cadded4330bddf4597dc530461",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5de1d496947148db932636fae105ce0d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 116 | Rows: 100000 | Time: 54.97 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ba338476585048bbb41ed9f685d07b0b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f6f36e749fbb4432b2f96c850887907d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 117 | Rows: 100000 | Time: 55.36 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b68f338399d045549e36e17748bbb125",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ee3da48e153144489e198ab648878d9b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 118 | Rows: 100000 | Time: 55.54 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8a1b89c4af9646dfbc9f62f0d813efb5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4fa43ae07b1045f2adcd7d64dda4a2a0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 119 | Rows: 100000 | Time: 54.93 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "20655e92f30c43cba6d346b2f2b052c4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b1fdd0ce6ef74d32a76efbc702bec022",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 120 | Rows: 100000 | Time: 53.91 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "85e27ab225fb4c5288a3eb0439e4d976",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0186646154f84d5c9c1fb2c1982af671",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 121 | Rows: 100000 | Time: 55.60 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "14540750942941cc8af7982df68484fc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cee6f6c215024059ac34dd1948d61ce5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 122 | Rows: 100000 | Time: 56.46 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "881326b954ff4b01993b81979b02e957",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "54864bec8ef4450bb228ae3c40afcd13",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 123 | Rows: 100000 | Time: 54.73 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aa6f98e5de7e40da810a94fcb3623a60",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "762ed55305d1477890b50d4e453c22ab",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 124 | Rows: 100000 | Time: 55.00 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5a8152b121ff41cf808439a11619b03b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df0c02977309484ba3bda74ad9ed18cc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 125 | Rows: 100000 | Time: 55.30 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "27075ce20771498583ae828e81c09fe2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a98099259964f238e3cbcad37eb4158",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 126 | Rows: 100000 | Time: 53.83 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6988063fa3714b208041aabee471e7bc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "379d154cdd7d407fa24ba3fe05d1a70f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 127 | Rows: 100000 | Time: 53.61 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c2ff709a093c4afcb8a82684b55150ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "619f3fb5f5f54c53ad7d7ef5c13986e3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 128 | Rows: 100000 | Time: 52.53 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b63d6bc0b3d343f78aa9c2b50634bab1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f9e60aa4eaf541649ba913892c105ae9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 129 | Rows: 100000 | Time: 55.85 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "095edb29d5a64b9eb0f49da501fa13cc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "27f97902f78447c7ae8645252a56641d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 130 | Rows: 100000 | Time: 55.56 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "de05c0a111be47a383da3fe56ac4e384",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bbd21f6176cd431e9c0e0dc0170e0779",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 131 | Rows: 100000 | Time: 55.16 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bd4f174cf7674732b06cde174824ead6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9d42c4e4dfd448cc8c6b0052c8770c39",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 132 | Rows: 100000 | Time: 53.82 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4329ab44064549049a22720d3309e764",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "be4cf39a1b6845b7af5e852f395f3038",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 133 | Rows: 100000 | Time: 55.20 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d612a622983d418ea9e7ca52620511a2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2b4d55b72da94eae84c64c4bb69efb07",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 134 | Rows: 100000 | Time: 55.19 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "542600d0b33d45b1b144ccc9772d19a6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5fc247974bf64d35962deab1f7d3b5ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 135 | Rows: 100000 | Time: 54.82 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "83e80ee2e0cf445cbc0d05de2049a481",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "06d65bd4f07f4a4481c541ea10a14bb5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 136 | Rows: 100000 | Time: 56.06 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e17d86beca1c4ff7894033c327db4040",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "47fed2874af54b02be13665777ea8922",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 137 | Rows: 100000 | Time: 54.97 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b5365fb16cec495bb225e7f58c57cd09",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5f4041d59e91400cbfcd50b88229b711",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 138 | Rows: 100000 | Time: 54.48 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3ecfb58fd54b4887a7895c2a0373c26f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "641a5683208a4a5f8162609e9d8afa4a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 139 | Rows: 100000 | Time: 54.61 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0d8082fbb8ed4124b24b462a33df8d9c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5bc02ad270924b67bc1fdec33ce1e480",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 140 | Rows: 100000 | Time: 53.74 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d75301c01c6d457db7f0826feda011c8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "be970b0bba1c47dba2d6bda4781ad89f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 141 | Rows: 100000 | Time: 53.52 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "64e7a3795f2b424a8a032dd0575ef538",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a510d6beb43f49dbae39fb058b6afe2f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 142 | Rows: 100000 | Time: 55.65 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eab103baceee422e9b88286b5cb4793d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e3ce4a5e270a4d608ca0640317ee9de9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 143 | Rows: 100000 | Time: 53.97 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "456d3434f4de4925886392da9842de89",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f8c3f9da0d0247779b857656391af698",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 144 | Rows: 100000 | Time: 54.40 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e1aca1c5627340dc86cda8ff6b37e217",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5ec08e5911654fa19737addbb018be8e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 145 | Rows: 100000 | Time: 55.60 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d2de35a3e7924c8a9e7aca6d1fb7c1fc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "56e92d8725c34265883cd16a62a0c28f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 146 | Rows: 100000 | Time: 54.78 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1fdbecc7406e4034802c74e9386f90ac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "70a5d4a0b9774c5a847ed5fbf48b80f8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 147 | Rows: 100000 | Time: 54.40 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "347635df34e84c6ba9a5a787b62a8490",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "045b882489b34f45ac4621f9ca709372",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 148 | Rows: 100000 | Time: 54.88 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3a338ec5f6854d07bc87d6e3ab6c70c6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fd300ea030e2470c9f89c40c4700f7c3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 149 | Rows: 100000 | Time: 56.27 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fae85a1825a640f2a963ca3ac6bb3d49",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d7a4e617cda0446986185f1f81db96f0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 150 | Rows: 100000 | Time: 53.74 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2a554c218e2b434cb6bfa916aa02c28b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d282ac4ea3ee48dbb68640fbf6bc744a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 151 | Rows: 100000 | Time: 55.23 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3bed94c748874ddeae63f622ba812fe3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7c50ac088b0e455396e2b2c818c6c59a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 152 | Rows: 100000 | Time: 55.26 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fda62c0654fd4a9bad6bb8e6eb3a4fc0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f17d06d291824149ac1d82f219b8aa82",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 153 | Rows: 100000 | Time: 54.96 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f6cefbe7aeaa4cbf980ac8d92ace1daa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "23455250b985492a87c868b5c7cc5f6c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 154 | Rows: 100000 | Time: 56.22 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a5583cefabc04759a3010c8612a4b13c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b1729153a79142719b34fedf46c2e465",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 155 | Rows: 100000 | Time: 54.70 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4508a84a2ad94a3883ab3429cf889f11",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "23914d5c59c1485e842fbf7411186de5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 156 | Rows: 100000 | Time: 55.76 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3e87edaacb084787b1f62c0ae37b5fdc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cd7fc7f9957b4d1b8fd52af99a379694",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 157 | Rows: 100000 | Time: 53.87 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b047db00a8c54adbb1013a84e8bbe791",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ac8011b99d4b46c3b9419df2eac116db",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 158 | Rows: 100000 | Time: 53.97 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "46ed9bdfe204450aaf498e653c894ce2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "61b50ef4a9284bb2925fc564149259c2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 159 | Rows: 100000 | Time: 55.37 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8c3f26a66538435f9ee48e52619eec92",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c3ddb8a911124d43b20aef1706096620",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 160 | Rows: 100000 | Time: 55.76 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "61bfef933be143abb69a50ecad33438b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "18b46e3db85340519d8f8b7c4a3b3248",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 161 | Rows: 100000 | Time: 55.58 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ec24bc2445f841e79ffad7a708468a52",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b72f50bbbab0454ba0115889ae0d7522",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 162 | Rows: 100000 | Time: 55.78 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "596f3672f9724ac9b802f763f43f3666",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d844d2f06d624a55b7b68fb7bd1ae1bf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 163 | Rows: 100000 | Time: 55.21 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3122eaf6c76a432284b7c53b3ba050d3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6749e3b8b30d4b28bd7345da7a148e08",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 164 | Rows: 100000 | Time: 56.27 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "27226b8e643d4445b159ea4a785e30a7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bcf5ed26ca9c4ff8bf47b1e0df9b3339",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 165 | Rows: 100000 | Time: 56.30 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1d3894df1ac24869af563f7e3f3237cc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a9cdc605721f48f08b146e5046542e54",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 166 | Rows: 100000 | Time: 56.02 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bf9708de048a41b49e784e2528164e12",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4c7be317fd1c4ce6b955d09d81673d75",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 167 | Rows: 100000 | Time: 55.57 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5fc379f9f7214fc6a5c4bc82d78587c3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0224a534047c4e04b5f3121ff41bb508",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 168 | Rows: 100000 | Time: 55.55 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "770e90c1506d48729c451b3bce143c14",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aedbf3226b2b46fe8eae02665d799a04",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 169 | Rows: 100000 | Time: 56.81 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "09cc5fceef7143469fa37f114d401f16",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6c98c745870a4ee29b0a64aa8de6defd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 170 | Rows: 100000 | Time: 55.74 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "67f91e93d1004ec9b77c5e17f3c071eb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3207f5f8fe2848fc87ca83059ea25a66",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 171 | Rows: 100000 | Time: 56.58 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0e910b3bce874ff48a0857922a568694",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "994d2119e70f4f65984e5b5e6b8fb717",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 172 | Rows: 100000 | Time: 56.46 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ef82b61b01a443d3b57b5dc84d8bf706",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d86fbda36340440192e93c13aa86018b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 173 | Rows: 100000 | Time: 55.59 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "64e69ee137e74ac9863705797c92c640",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e3521711e5c0491dbb51a49cb9b33212",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 174 | Rows: 100000 | Time: 53.90 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f93437689376423f9084872a18ee9ea9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "31a61fb16d6c4cdeb5e2049a004929c7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 175 | Rows: 100000 | Time: 55.13 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f91d28b53e914c3a85f1caa2e0f19525",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5444cbb8c55e4698b8f4de0652b7d150",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 176 | Rows: 100000 | Time: 53.81 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3adf20cb9e8243d7b1d3ac8f06d2ca44",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5018c63a2c0546ebaf4fe8ccda972271",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 177 | Rows: 100000 | Time: 56.33 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "26c0faa18f2940598b8b3ca50bad9add",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5e61d517bc734e91a6de01238623cd18",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 178 | Rows: 100000 | Time: 55.36 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e55a0934fb8148af8008a7a715c080d7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1647a26b89734a2299960fa6164df56f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 179 | Rows: 100000 | Time: 54.97 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7851328014104ad8a68e5df5c421e013",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "02d6eb5af3664293a91dd1ab012dea28",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 180 | Rows: 100000 | Time: 56.63 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "04b6d8accf6d4881b291ad8345641a5b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "71c0176e85b541e6a1f4e01d87145d47",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 181 | Rows: 100000 | Time: 54.41 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a0cafcfcf06b4a1bb59d69989183fcb5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "64be9705cd344fffa494bfcbe6ccad03",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 182 | Rows: 100000 | Time: 56.11 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0eab2010dcab4a36b3365b2fa68c49b8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "52b094ee3255410bb50a9d5a353cde9f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 183 | Rows: 100000 | Time: 56.42 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "99032ffc684d44b396eacd6df54e249b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3aae462b58d2460caddd9f769bde43ed",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 184 | Rows: 100000 | Time: 56.36 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c9f19966690f4ef7826df1ccab78775d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0f621209311d4ac08314890f7f5772e6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 185 | Rows: 100000 | Time: 57.40 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2049bca2eda24825af3a6c826749012c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a24c62d40d41414c8eed04e1e5108d77",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 186 | Rows: 100000 | Time: 55.19 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "470f72f30000406b8fa3138ec3acf0a5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c11f0d4b9e5f4d0bbe458bd770a9255a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 187 | Rows: 100000 | Time: 55.36 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2d1988b73dd64f9684baa0d2c9680afa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0e8aa823e7be47d89d341aef8c688cf3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 188 | Rows: 100000 | Time: 57.28 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0e52ac1015ff44e89f81e9b1f5c1fb3e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3f5238135c3d48a19a2b5d5c1f0dcbb6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 189 | Rows: 100000 | Time: 55.09 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4e28127288f74a5abd7369b039b82839",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "09b0bc3e8d3949458d68ea2d0265f960",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 190 | Rows: 100000 | Time: 56.96 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "674c4c87b06a4a52b766c490bb047aee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f182466697454b5ba324f5daeb795ffc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 191 | Rows: 100000 | Time: 54.87 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5287c2333cc943dba5f9bb6bd3ee0568",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "63b3e49603d84da19bb65a24f60a3090",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=6250), Label(value='0 / 6250'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 192 | Rows: 100000 | Time: 57.44 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e5903c2ddc134d769406ba1e77f1a989",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=1825), Label(value='0 / 1825'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "849f7eb839cb4a77b67ccc68f02f2a30",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=1825), Label(value='0 / 1825'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved chunk 193 | Rows: 29189 | Time: 20.75 sec\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Preprocess ion mode, precursor m/z, and adducts\n",
+    "#Chunk df_massspecgym\n",
+    "chunk_size = 100_000\n",
+    "n_chunks = (len(df_massspecgym) + chunk_size - 1) // chunk_size\n",
+    "\n",
+    "for i in range(n_chunks):\n",
+    "    output_file = f\"processed_chunks/df_massspecgym_chunk_{i:03}.parquet\"\n",
+    "    if os.path.exists(output_file):\n",
+    "        print(f\"⏩ Skipping chunk {i} (already exists)\")\n",
+    "        continue\n",
+    "\n",
+    "    df_chunk = df_massspecgym.iloc[i * chunk_size : (i + 1) * chunk_size].copy()\n",
+    "    preprocess_chunk(df_chunk, i)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: Pandarallel will run on 8 workers.\n",
+      "INFO: Pandarallel will use Memory file system to transfer data between the main process and workers.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   1%|                      | 1/194 [01:13<3:55:18, 73.15s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_000.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   1%|▏                     | 2/194 [02:23<3:49:14, 71.64s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_001.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   2%|▎                     | 3/194 [03:33<3:45:52, 70.95s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_002.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   2%|▍                     | 4/194 [04:43<3:43:25, 70.55s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_003.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   3%|▌                     | 5/194 [05:56<3:44:16, 71.20s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_004.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   3%|▋                     | 6/194 [07:08<3:44:44, 71.73s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_005.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   4%|▊                     | 7/194 [08:20<3:43:40, 71.76s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_006.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   4%|▉                     | 8/194 [09:31<3:41:19, 71.39s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_007.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   5%|█                     | 9/194 [10:43<3:40:31, 71.52s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_008.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   5%|█                    | 10/194 [11:53<3:37:58, 71.08s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_009.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   6%|█▏                   | 11/194 [13:03<3:35:45, 70.74s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_010.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   6%|█▎                   | 12/194 [14:13<3:34:25, 70.69s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_011.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   7%|█▍                   | 13/194 [15:24<3:32:57, 70.59s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_012.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   7%|█▌                   | 14/194 [16:35<3:32:09, 70.72s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_013.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   8%|█▌                   | 15/194 [17:46<3:31:23, 70.86s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_014.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   8%|█▋                   | 16/194 [18:57<3:30:15, 70.87s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_015.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   9%|█▊                   | 17/194 [20:07<3:28:44, 70.76s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_016.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:   9%|█▉                   | 18/194 [21:18<3:27:15, 70.66s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_017.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  10%|██                   | 19/194 [22:29<3:26:39, 70.85s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_018.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  10%|██▏                  | 20/194 [23:40<3:25:52, 70.99s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_019.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  11%|██▎                  | 21/194 [24:54<3:26:47, 71.72s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_020.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  11%|██▍                  | 22/194 [26:06<3:26:24, 72.00s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_021.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  12%|██▍                  | 23/194 [27:18<3:24:54, 71.90s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_022.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  12%|██▌                  | 24/194 [28:29<3:22:51, 71.60s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_023.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  13%|██▋                  | 25/194 [29:39<3:20:39, 71.24s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_024.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  13%|██▊                  | 26/194 [30:49<3:18:33, 70.92s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_025.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  14%|██▉                  | 27/194 [32:00<3:16:54, 70.74s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_026.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  14%|███                  | 28/194 [33:10<3:15:38, 70.71s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_027.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  15%|███▏                 | 29/194 [34:21<3:14:18, 70.66s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_028.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  15%|███▏                 | 30/194 [35:32<3:13:11, 70.68s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_029.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  16%|███▎                 | 31/194 [36:42<3:11:54, 70.64s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_030.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  16%|███▍                 | 32/194 [37:53<3:10:23, 70.51s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_031.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  17%|███▌                 | 33/194 [39:04<3:10:09, 70.87s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_032.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  18%|███▋                 | 34/194 [40:15<3:08:56, 70.85s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_033.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  18%|███▊                 | 35/194 [41:27<3:08:37, 71.18s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_034.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  19%|███▉                 | 36/194 [42:41<3:09:25, 71.93s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_035.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  19%|████                 | 37/194 [43:51<3:07:08, 71.52s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_036.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  20%|████                 | 38/194 [45:02<3:05:43, 71.43s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_037.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  20%|████▏                | 39/194 [46:16<3:06:18, 72.12s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_038.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  21%|████▎                | 40/194 [47:28<3:05:09, 72.14s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_039.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  21%|████▍                | 41/194 [48:41<3:04:02, 72.17s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_040.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  22%|████▌                | 42/194 [49:54<3:03:53, 72.59s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_041.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  22%|████▋                | 43/194 [51:09<3:04:26, 73.29s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_042.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  23%|████▊                | 44/194 [52:24<3:04:29, 73.80s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_043.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  23%|████▊                | 45/194 [53:42<3:06:21, 75.05s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_044.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  24%|████▉                | 46/194 [54:59<3:06:12, 75.49s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_045.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  24%|█████                | 47/194 [56:13<3:03:54, 75.06s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_046.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  25%|█████▏               | 48/194 [57:24<3:00:11, 74.05s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_047.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  25%|█████▎               | 49/194 [58:36<2:57:19, 73.37s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_048.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  26%|█████▍               | 50/194 [59:50<2:56:32, 73.56s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_049.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  26%|████▉              | 51/194 [1:01:04<2:55:22, 73.58s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_050.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  27%|█████              | 52/194 [1:02:18<2:54:26, 73.71s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_051.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  27%|█████▏             | 53/194 [1:03:34<2:55:20, 74.61s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_052.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  28%|█████▎             | 54/194 [1:04:49<2:54:21, 74.73s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_053.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  28%|█████▍             | 55/194 [1:06:06<2:54:40, 75.40s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_054.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  29%|█████▍             | 56/194 [1:07:22<2:53:23, 75.39s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_055.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  29%|█████▌             | 57/194 [1:08:38<2:52:26, 75.52s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_056.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  30%|█████▋             | 58/194 [1:09:55<2:52:35, 76.15s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_057.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  30%|█████▊             | 59/194 [1:11:10<2:50:43, 75.87s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_058.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  31%|█████▉             | 60/194 [1:12:27<2:49:49, 76.04s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_059.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  31%|█████▉             | 61/194 [1:13:40<2:46:38, 75.17s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_060.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  32%|██████             | 62/194 [1:14:56<2:45:37, 75.28s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_061.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  32%|██████▏            | 63/194 [1:16:11<2:44:30, 75.35s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_062.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  33%|██████▎            | 64/194 [1:17:27<2:43:39, 75.53s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_063.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  34%|██████▎            | 65/194 [1:18:39<2:40:08, 74.48s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_064.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  34%|██████▍            | 66/194 [1:19:51<2:37:03, 73.62s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_065.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  35%|██████▌            | 67/194 [1:21:02<2:34:16, 72.88s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_066.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  35%|██████▋            | 68/194 [1:22:13<2:31:53, 72.33s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_067.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  36%|██████▊            | 69/194 [1:23:25<2:30:15, 72.13s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_068.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  36%|██████▊            | 70/194 [1:24:35<2:28:13, 71.72s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_069.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  37%|██████▉            | 71/194 [1:25:46<2:26:08, 71.29s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_070.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  37%|███████            | 72/194 [1:26:56<2:24:40, 71.15s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_071.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  38%|███████▏           | 73/194 [1:28:08<2:23:36, 71.21s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_072.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  38%|███████▏           | 74/194 [1:29:20<2:23:12, 71.61s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_073.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  39%|███████▎           | 75/194 [1:30:31<2:21:25, 71.31s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_074.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  39%|███████▍           | 76/194 [1:31:42<2:19:48, 71.09s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_075.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  40%|███████▌           | 77/194 [1:32:53<2:18:55, 71.25s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_076.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  40%|███████▋           | 78/194 [1:34:04<2:17:26, 71.09s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_077.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  41%|███████▋           | 79/194 [1:35:14<2:15:59, 70.95s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_078.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  41%|███████▊           | 80/194 [1:36:25<2:14:41, 70.89s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_079.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  42%|███████▉           | 81/194 [1:37:36<2:13:36, 70.94s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_080.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  42%|████████           | 82/194 [1:38:47<2:12:04, 70.76s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_081.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  43%|████████▏          | 83/194 [1:39:58<2:11:13, 70.93s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_082.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  43%|████████▏          | 84/194 [1:41:08<2:09:38, 70.71s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_083.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  44%|████████▎          | 85/194 [1:42:18<2:08:12, 70.57s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_084.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  44%|████████▍          | 86/194 [1:43:30<2:07:51, 71.03s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_085.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  45%|████████▌          | 87/194 [1:44:41<2:06:29, 70.93s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_086.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  45%|████████▌          | 88/194 [1:45:52<2:05:17, 70.92s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_087.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  46%|████████▋          | 89/194 [1:47:03<2:03:55, 70.81s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_088.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  46%|████████▊          | 90/194 [1:48:13<2:02:31, 70.69s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_089.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  47%|████████▉          | 91/194 [1:49:23<2:01:04, 70.53s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_090.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  47%|█████████          | 92/194 [1:50:34<2:00:02, 70.61s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_091.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  48%|█████████          | 93/194 [1:51:45<1:58:52, 70.62s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_092.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  48%|█████████▏         | 94/194 [1:52:56<1:57:49, 70.70s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_093.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  49%|█████████▎         | 95/194 [1:54:06<1:56:46, 70.78s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_094.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  49%|█████████▍         | 96/194 [1:55:17<1:55:20, 70.62s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_095.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  50%|█████████▌         | 97/194 [1:56:29<1:54:47, 71.01s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_096.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  51%|█████████▌         | 98/194 [1:57:40<1:53:38, 71.03s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_097.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  51%|█████████▋         | 99/194 [1:58:51<1:52:25, 71.01s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_098.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  52%|█████████▎        | 100/194 [2:00:01<1:50:50, 70.75s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_099.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  52%|█████████▎        | 101/194 [2:01:11<1:49:29, 70.64s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_100.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  53%|█████████▍        | 102/194 [2:02:21<1:48:09, 70.53s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_101.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  53%|█████████▌        | 103/194 [2:03:32<1:46:54, 70.49s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_102.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  54%|█████████▋        | 104/194 [2:04:42<1:45:41, 70.46s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_103.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  54%|█████████▋        | 105/194 [2:05:53<1:44:28, 70.43s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_104.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  55%|█████████▊        | 106/194 [2:07:03<1:43:25, 70.51s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_105.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  55%|█████████▉        | 107/194 [2:08:14<1:42:28, 70.67s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_106.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  56%|██████████        | 108/194 [2:09:25<1:41:03, 70.51s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_107.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  56%|██████████        | 109/194 [2:10:35<1:39:51, 70.49s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_108.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  57%|██████████▏       | 110/194 [2:11:45<1:38:38, 70.46s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_109.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  57%|██████████▎       | 111/194 [2:12:56<1:37:43, 70.64s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_110.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  58%|██████████▍       | 112/194 [2:14:07<1:36:32, 70.64s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_111.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  58%|██████████▍       | 113/194 [2:15:18<1:35:20, 70.62s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_112.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  59%|██████████▌       | 114/194 [2:16:28<1:33:59, 70.49s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_113.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  59%|██████████▋       | 115/194 [2:17:39<1:32:55, 70.58s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_114.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  60%|██████████▊       | 116/194 [2:18:49<1:31:44, 70.57s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_115.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  60%|██████████▊       | 117/194 [2:20:00<1:30:34, 70.58s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_116.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  61%|██████████▉       | 118/194 [2:21:11<1:29:41, 70.81s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_117.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  61%|███████████       | 119/194 [2:22:21<1:28:19, 70.66s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_118.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  62%|███████████▏      | 120/194 [2:23:32<1:27:02, 70.57s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_119.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  62%|███████████▏      | 121/194 [2:24:42<1:25:47, 70.51s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_120.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  63%|███████████▎      | 122/194 [2:25:52<1:24:27, 70.38s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_121.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  63%|███████████▍      | 123/194 [2:27:03<1:23:19, 70.41s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_122.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  64%|███████████▌      | 124/194 [2:28:13<1:22:11, 70.45s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_123.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  64%|███████████▌      | 125/194 [2:29:24<1:20:59, 70.43s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_124.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  65%|███████████▋      | 126/194 [2:30:34<1:19:50, 70.45s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_125.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  65%|███████████▊      | 127/194 [2:31:45<1:18:43, 70.50s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_126.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  66%|███████████▉      | 128/194 [2:32:55<1:17:21, 70.33s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_127.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  66%|███████████▉      | 129/194 [2:34:05<1:16:14, 70.38s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_128.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  67%|████████████      | 130/194 [2:35:16<1:15:22, 70.66s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_129.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  68%|████████████▏     | 131/194 [2:36:27<1:14:00, 70.48s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_130.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  68%|████████████▏     | 132/194 [2:37:37<1:12:57, 70.61s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_131.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  69%|████████████▎     | 133/194 [2:38:48<1:11:42, 70.54s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_132.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  69%|████████████▍     | 134/194 [2:39:58<1:10:25, 70.43s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_133.pkl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing chunks:  70%|████████████▌     | 135/194 [2:41:10<1:09:42, 70.88s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Saved graph_data_chunks/graph_data_chunk_134.pkl\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Preprocess ion mode, precursor m/z, and adducts\n",
+    "#Process and save each chunk safely — minimal RAM use\n",
+    "import pandas as pd\n",
+    "import pickle\n",
+    "import glob\n",
+    "import gc\n",
+    "import os\n",
+    "from pandarallel import pandarallel\n",
+    "from tqdm import tqdm\n",
+    "import time\n",
+    "\n",
+    "start_time = time.time()\n",
+    "pandarallel.initialize(nb_workers=8, progress_bar=False)\n",
+    "\n",
+    "# Load adduct mapping\n",
+    "df_massspecgym = pd.read_parquet(\"df_massspecgym.parquet\", columns=[\"adduct\"])\n",
+    "adduct_types = df_massspecgym['adduct'].unique()\n",
+    "adduct_to_idx = {adduct: i for i, adduct in enumerate(adduct_types)}\n",
+    "del df_massspecgym\n",
+    "\n",
+    "chunk_files = sorted(glob.glob(\"processed_chunks/df_massspecgym_chunk_*.parquet\"))\n",
+    "output_dir = \"graph_data_chunks\"\n",
+    "os.makedirs(output_dir, exist_ok=True)\n",
+    "\n",
+    "for i, chunk_file in enumerate(tqdm(chunk_files, desc=\"Processing chunks\")):\n",
+    "    df = pd.read_parquet(chunk_file)\n",
+    "\n",
+    "    graph_data = df.parallel_apply(\n",
+    "        lambda row: bin_spectrum_to_graph(\n",
+    "            row['mzs'], row['intensities'], row['ion_mode'],\n",
+    "            row['precursor_mz'], row['adduct']\n",
+    "        )[1],\n",
+    "        axis=1\n",
+    "    )\n",
+    "\n",
+    "    # Save per chunk — no accumulation\n",
+    "    out_path = os.path.join(output_dir, f\"graph_data_chunk_{i:03}.pkl\")\n",
+    "    with open(out_path, \"wb\") as f:\n",
+    "        pickle.dump(graph_data.tolist(), f)\n",
+    "\n",
+    "    del df\n",
+    "    del graph_data\n",
+    "    gc.collect()\n",
+    "    print(f\"✅ Saved {out_path}\")\n",
+    "\n",
+    "print(\"🎉 All chunks saved individually.\")\n",
+    "print(\"🕒 Completed in {:.2f} seconds\".format(time.time() - start_time))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cf17f136530c4e0ab2d098e25454c6e3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=1445), Label(value='0 / 1445'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a3978a13fe38466d81f1717c88abb06f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntProgress(value=0, description='0.00%', max=1445), Label(value='0 / 1445'))), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ df_external processed and saved in 33.56 seconds\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Preprocess ion mode, precursor m/z, and adducts\n",
+    "#Full Processing of df_external\n",
+    "import time\n",
+    "import pickle\n",
+    "\n",
+    "start_time = time.time()\n",
+    "\n",
+    "# Compute ion_mode\n",
+    "df_external['ion_mode'] = df_external['adduct'].parallel_apply(\n",
+    "    lambda x: 0 if '+' in str(x) else 1 if '-' in str(x) else 0\n",
+    ").fillna(0)\n",
+    "\n",
+    "# Compute precursor_bin\n",
+    "df_external['precursor_bin'] = pd.qcut(\n",
+    "    df_external['precursor_mz'], q=100, labels=False, duplicates='drop'\n",
+    ")\n",
+    "\n",
+    "# Map adduct to index\n",
+    "df_external['adduct_idx'] = df_external['adduct'].map(adduct_to_idx)\n",
+    "\n",
+    "# Generate binned and graph_data columns\n",
+    "df_external[['binned', 'graph_data']] = df_external.parallel_apply(\n",
+    "    lambda row: pd.Series(bin_spectrum_to_graph(\n",
+    "        row['mzs'], row['intensities'], row['ion_mode'],\n",
+    "        row['precursor_mz'], row['adduct']\n",
+    "    )),\n",
+    "    axis=1\n",
+    ")\n",
+    "\n",
+    "# 🔒 Save graph_data separately (optional)\n",
+    "with open(\"df_external_graph_data.pkl\", \"wb\") as f:\n",
+    "    pickle.dump(df_external['graph_data'].tolist(), f)\n",
+    "\n",
+    "# ❌ Drop graph_data column before saving to parquet\n",
+    "df_external.drop(columns=['graph_data'], inplace=True)\n",
+    "\n",
+    "# ✅ Save remaining data to Parquet\n",
+    "df_external.to_parquet(\"df_external_processed.parquet\")\n",
+    "\n",
+    "print(\"✅ df_external processed and saved in {:.2f} seconds\".format(time.time() - start_time))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Wrote chunk 0 / 194\n",
+      "✅ Wrote chunk 1 / 194 in 6.07s\n",
+      "✅ Wrote chunk 2 / 194 in 6.17s\n",
+      "✅ Wrote chunk 3 / 194 in 6.10s\n",
+      "✅ Wrote chunk 4 / 194 in 6.05s\n",
+      "✅ Wrote chunk 5 / 194 in 6.10s\n",
+      "✅ Wrote chunk 6 / 194 in 5.94s\n",
+      "✅ Wrote chunk 7 / 194 in 5.91s\n",
+      "✅ Wrote chunk 8 / 194 in 6.04s\n",
+      "✅ Wrote chunk 9 / 194 in 5.93s\n",
+      "✅ Wrote chunk 10 / 194 in 5.93s\n",
+      "✅ Wrote chunk 11 / 194 in 6.01s\n",
+      "✅ Wrote chunk 12 / 194 in 6.34s\n",
+      "✅ Wrote chunk 13 / 194 in 7.31s\n",
+      "✅ Wrote chunk 14 / 194 in 6.02s\n",
+      "✅ Wrote chunk 15 / 194 in 6.03s\n",
+      "✅ Wrote chunk 16 / 194 in 5.95s\n",
+      "✅ Wrote chunk 17 / 194 in 5.95s\n",
+      "✅ Wrote chunk 18 / 194 in 6.70s\n",
+      "✅ Wrote chunk 19 / 194 in 6.01s\n",
+      "✅ Wrote chunk 20 / 194 in 6.07s\n",
+      "✅ Wrote chunk 21 / 194 in 5.99s\n",
+      "✅ Wrote chunk 22 / 194 in 5.92s\n",
+      "✅ Wrote chunk 23 / 194 in 6.16s\n",
+      "✅ Wrote chunk 24 / 194 in 5.94s\n",
+      "✅ Wrote chunk 25 / 194 in 5.85s\n",
+      "✅ Wrote chunk 26 / 194 in 5.92s\n",
+      "✅ Wrote chunk 27 / 194 in 5.90s\n",
+      "✅ Wrote chunk 28 / 194 in 5.87s\n",
+      "✅ Wrote chunk 29 / 194 in 7.08s\n",
+      "✅ Wrote chunk 30 / 194 in 5.94s\n",
+      "✅ Wrote chunk 31 / 194 in 5.97s\n",
+      "✅ Wrote chunk 32 / 194 in 5.98s\n",
+      "✅ Wrote chunk 33 / 194 in 5.95s\n",
+      "✅ Wrote chunk 34 / 194 in 6.42s\n",
+      "✅ Wrote chunk 35 / 194 in 6.00s\n",
+      "✅ Wrote chunk 36 / 194 in 5.93s\n",
+      "✅ Wrote chunk 37 / 194 in 6.01s\n",
+      "✅ Wrote chunk 38 / 194 in 5.90s\n",
+      "✅ Wrote chunk 39 / 194 in 5.96s\n",
+      "✅ Wrote chunk 40 / 194 in 6.02s\n",
+      "✅ Wrote chunk 41 / 194 in 6.46s\n",
+      "✅ Wrote chunk 42 / 194 in 6.15s\n",
+      "✅ Wrote chunk 43 / 194 in 6.36s\n",
+      "✅ Wrote chunk 44 / 194 in 6.29s\n",
+      "✅ Wrote chunk 45 / 194 in 6.23s\n",
+      "✅ Wrote chunk 46 / 194 in 6.67s\n",
+      "✅ Wrote chunk 47 / 194 in 5.98s\n",
+      "✅ Wrote chunk 48 / 194 in 6.13s\n",
+      "✅ Wrote chunk 49 / 194 in 6.26s\n",
+      "✅ Wrote chunk 50 / 194 in 6.14s\n",
+      "✅ Wrote chunk 51 / 194 in 6.88s\n",
+      "✅ Wrote chunk 52 / 194 in 6.25s\n",
+      "✅ Wrote chunk 53 / 194 in 6.43s\n",
+      "✅ Wrote chunk 54 / 194 in 6.24s\n",
+      "✅ Wrote chunk 55 / 194 in 6.17s\n",
+      "✅ Wrote chunk 56 / 194 in 6.17s\n",
+      "✅ Wrote chunk 57 / 194 in 6.27s\n",
+      "✅ Wrote chunk 58 / 194 in 6.26s\n",
+      "✅ Wrote chunk 59 / 194 in 6.17s\n",
+      "✅ Wrote chunk 60 / 194 in 6.13s\n",
+      "✅ Wrote chunk 61 / 194 in 6.89s\n",
+      "✅ Wrote chunk 62 / 194 in 6.21s\n",
+      "✅ Wrote chunk 63 / 194 in 6.25s\n",
+      "✅ Wrote chunk 64 / 194 in 6.07s\n",
+      "✅ Wrote chunk 65 / 194 in 5.94s\n",
+      "✅ Wrote chunk 66 / 194 in 5.87s\n",
+      "✅ Wrote chunk 67 / 194 in 6.43s\n",
+      "✅ Wrote chunk 68 / 194 in 6.00s\n",
+      "✅ Wrote chunk 69 / 194 in 5.95s\n",
+      "✅ Wrote chunk 70 / 194 in 5.96s\n",
+      "✅ Wrote chunk 71 / 194 in 5.96s\n",
+      "✅ Wrote chunk 72 / 194 in 5.97s\n",
+      "✅ Wrote chunk 73 / 194 in 7.00s\n",
+      "✅ Wrote chunk 74 / 194 in 5.98s\n",
+      "✅ Wrote chunk 75 / 194 in 5.96s\n",
+      "✅ Wrote chunk 76 / 194 in 5.93s\n",
+      "✅ Wrote chunk 77 / 194 in 5.96s\n",
+      "✅ Wrote chunk 78 / 194 in 6.37s\n",
+      "✅ Wrote chunk 79 / 194 in 6.00s\n",
+      "✅ Wrote chunk 80 / 194 in 6.07s\n",
+      "✅ Wrote chunk 81 / 194 in 5.95s\n",
+      "✅ Wrote chunk 82 / 194 in 6.13s\n",
+      "✅ Wrote chunk 83 / 194 in 5.98s\n",
+      "✅ Wrote chunk 84 / 194 in 5.96s\n",
+      "✅ Wrote chunk 85 / 194 in 6.09s\n",
+      "✅ Wrote chunk 86 / 194 in 6.02s\n",
+      "✅ Wrote chunk 87 / 194 in 6.24s\n",
+      "✅ Wrote chunk 88 / 194 in 5.95s\n",
+      "✅ Wrote chunk 89 / 194 in 5.89s\n",
+      "✅ Wrote chunk 90 / 194 in 5.94s\n",
+      "✅ Wrote chunk 91 / 194 in 7.03s\n",
+      "✅ Wrote chunk 92 / 194 in 5.96s\n",
+      "✅ Wrote chunk 93 / 194 in 5.91s\n",
+      "✅ Wrote chunk 94 / 194 in 5.95s\n",
+      "✅ Wrote chunk 95 / 194 in 5.93s\n",
+      "✅ Wrote chunk 96 / 194 in 6.26s\n",
+      "✅ Wrote chunk 97 / 194 in 6.20s\n",
+      "✅ Wrote chunk 98 / 194 in 5.95s\n",
+      "✅ Wrote chunk 99 / 194 in 6.16s\n",
+      "✅ Wrote chunk 100 / 194 in 5.95s\n",
+      "✅ Wrote chunk 101 / 194 in 6.45s\n",
+      "✅ Wrote chunk 102 / 194 in 6.25s\n",
+      "✅ Wrote chunk 103 / 194 in 5.91s\n",
+      "✅ Wrote chunk 104 / 194 in 5.94s\n",
+      "✅ Wrote chunk 105 / 194 in 5.93s\n",
+      "✅ Wrote chunk 106 / 194 in 6.44s\n",
+      "✅ Wrote chunk 107 / 194 in 5.91s\n",
+      "✅ Wrote chunk 108 / 194 in 5.89s\n",
+      "✅ Wrote chunk 109 / 194 in 6.14s\n",
+      "✅ Wrote chunk 110 / 194 in 6.01s\n",
+      "✅ Wrote chunk 111 / 194 in 6.05s\n",
+      "✅ Wrote chunk 112 / 194 in 5.98s\n",
+      "✅ Wrote chunk 113 / 194 in 5.90s\n",
+      "✅ Wrote chunk 114 / 194 in 5.91s\n",
+      "✅ Wrote chunk 115 / 194 in 5.92s\n",
+      "✅ Wrote chunk 116 / 194 in 5.91s\n",
+      "✅ Wrote chunk 117 / 194 in 5.90s\n",
+      "✅ Wrote chunk 118 / 194 in 5.92s\n",
+      "✅ Wrote chunk 119 / 194 in 5.92s\n",
+      "✅ Wrote chunk 120 / 194 in 5.91s\n",
+      "✅ Wrote chunk 121 / 194 in 5.94s\n",
+      "✅ Wrote chunk 122 / 194 in 5.94s\n",
+      "✅ Wrote chunk 123 / 194 in 5.92s\n",
+      "✅ Wrote chunk 124 / 194 in 5.93s\n",
+      "✅ Wrote chunk 125 / 194 in 6.58s\n",
+      "✅ Wrote chunk 126 / 194 in 5.89s\n",
+      "✅ Wrote chunk 127 / 194 in 5.89s\n",
+      "✅ Wrote chunk 128 / 194 in 5.89s\n",
+      "✅ Wrote chunk 129 / 194 in 5.90s\n",
+      "✅ Wrote chunk 130 / 194 in 5.89s\n",
+      "✅ Wrote chunk 131 / 194 in 6.58s\n",
+      "✅ Wrote chunk 132 / 194 in 5.98s\n",
+      "✅ Wrote chunk 133 / 194 in 5.92s\n",
+      "✅ Wrote chunk 134 / 194 in 5.92s\n",
+      "✅ Wrote chunk 135 / 194 in 5.92s\n",
+      "✅ Wrote chunk 136 / 194 in 5.94s\n",
+      "✅ Wrote chunk 137 / 194 in 6.41s\n",
+      "✅ Wrote chunk 138 / 194 in 5.91s\n",
+      "✅ Wrote chunk 139 / 194 in 5.86s\n",
+      "✅ Wrote chunk 140 / 194 in 5.93s\n",
+      "✅ Wrote chunk 141 / 194 in 5.91s\n",
+      "✅ Wrote chunk 142 / 194 in 5.92s\n",
+      "✅ Wrote chunk 143 / 194 in 6.52s\n",
+      "✅ Wrote chunk 144 / 194 in 5.92s\n",
+      "✅ Wrote chunk 145 / 194 in 5.96s\n",
+      "✅ Wrote chunk 146 / 194 in 5.87s\n",
+      "✅ Wrote chunk 147 / 194 in 5.93s\n",
+      "✅ Wrote chunk 148 / 194 in 5.92s\n",
+      "✅ Wrote chunk 149 / 194 in 6.31s\n",
+      "✅ Wrote chunk 150 / 194 in 5.88s\n",
+      "✅ Wrote chunk 151 / 194 in 5.89s\n",
+      "✅ Wrote chunk 152 / 194 in 5.93s\n",
+      "✅ Wrote chunk 153 / 194 in 5.93s\n",
+      "✅ Wrote chunk 154 / 194 in 5.95s\n",
+      "✅ Wrote chunk 155 / 194 in 6.60s\n",
+      "✅ Wrote chunk 156 / 194 in 5.92s\n",
+      "✅ Wrote chunk 157 / 194 in 5.94s\n",
+      "✅ Wrote chunk 158 / 194 in 5.93s\n",
+      "✅ Wrote chunk 159 / 194 in 5.98s\n",
+      "✅ Wrote chunk 160 / 194 in 5.99s\n",
+      "✅ Wrote chunk 161 / 194 in 6.15s\n",
+      "✅ Wrote chunk 162 / 194 in 5.86s\n",
+      "✅ Wrote chunk 163 / 194 in 5.92s\n",
+      "✅ Wrote chunk 164 / 194 in 6.10s\n",
+      "✅ Wrote chunk 165 / 194 in 5.90s\n",
+      "✅ Wrote chunk 166 / 194 in 6.02s\n",
+      "✅ Wrote chunk 167 / 194 in 6.17s\n",
+      "✅ Wrote chunk 168 / 194 in 5.89s\n",
+      "✅ Wrote chunk 169 / 194 in 5.88s\n",
+      "✅ Wrote chunk 170 / 194 in 5.90s\n",
+      "✅ Wrote chunk 171 / 194 in 5.92s\n",
+      "✅ Wrote chunk 172 / 194 in 5.93s\n",
+      "✅ Wrote chunk 173 / 194 in 6.61s\n",
+      "✅ Wrote chunk 174 / 194 in 5.90s\n",
+      "✅ Wrote chunk 175 / 194 in 5.93s\n",
+      "✅ Wrote chunk 176 / 194 in 5.94s\n",
+      "✅ Wrote chunk 177 / 194 in 5.94s\n",
+      "✅ Wrote chunk 178 / 194 in 6.01s\n",
+      "✅ Wrote chunk 179 / 194 in 6.24s\n",
+      "✅ Wrote chunk 180 / 194 in 5.99s\n",
+      "✅ Wrote chunk 181 / 194 in 5.94s\n",
+      "✅ Wrote chunk 182 / 194 in 5.92s\n",
+      "✅ Wrote chunk 183 / 194 in 5.95s\n",
+      "✅ Wrote chunk 184 / 194 in 5.95s\n",
+      "✅ Wrote chunk 185 / 194 in 6.25s\n",
+      "✅ Wrote chunk 186 / 194 in 5.97s\n",
+      "✅ Wrote chunk 187 / 194 in 5.93s\n",
+      "✅ Wrote chunk 188 / 194 in 5.92s\n",
+      "✅ Wrote chunk 189 / 194 in 5.91s\n",
+      "✅ Wrote chunk 190 / 194 in 5.92s\n",
+      "✅ Wrote chunk 191 / 194 in 6.52s\n",
+      "✅ Wrote chunk 192 / 194 in 5.94s\n",
+      "✅ Wrote chunk 193 / 194 in 1.75s\n",
+      "🎉 Done merging 194 chunks ➜ df_massspecgym_processed_full.parquet\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Preprocess ion mode, precursor m/z, and adducts\n",
+    "import pandas as pd\n",
+    "import glob\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.parquet as pq\n",
+    "import time\n",
+    "\n",
+    "output_path = \"df_massspecgym_processed_full.parquet\"\n",
+    "chunk_files = sorted(glob.glob(\"processed_chunks/df_massspecgym_chunk_*.parquet\"))\n",
+    "\n",
+    "first_df = pd.read_parquet(chunk_files[0])\n",
+    "first_df['precursor_bin'] = first_df['precursor_bin'].fillna(-1).astype('int64')\n",
+    "\n",
+    "table = pa.Table.from_pandas(first_df)\n",
+    "writer = pq.ParquetWriter(output_path, table.schema)\n",
+    "\n",
+    "writer.write_table(table)\n",
+    "print(f\"✅ Wrote chunk 0 / {len(chunk_files)}\")\n",
+    "\n",
+    "for i, file in enumerate(chunk_files[1:], start=1):\n",
+    "    start = time.time()\n",
+    "    df = pd.read_parquet(file)\n",
+    "\n",
+    "    df['precursor_bin'] = df['precursor_bin'].fillna(-1).astype('int64')\n",
+    "    df = df[first_df.columns]\n",
+    "\n",
+    "    table = pa.Table.from_pandas(df)\n",
+    "    writer.write_table(table)\n",
+    "    print(f\"✅ Wrote chunk {i} / {len(chunk_files)} in {time.time() - start:.2f}s\")\n",
+    "\n",
+    "writer.close()\n",
+    "print(f\"🎉 Done merging {len(chunk_files)} chunks ➜ {output_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Vocabulary size: 21, Supervised MAX_LEN: 272, Pretrain MAX_LEN: 100\n",
+      "Completed in 32.10s\n",
+      "Completed in 0.00s\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SMILES Tokenization with Stereochemistry\n",
+    "\n",
+    "import pyarrow.parquet as pq\n",
+    "import pyarrow as pa\n",
+    "import time \n",
+    "# Special tokens\n",
+    "PAD_TOKEN = \"<PAD>\"\n",
+    "SOS_TOKEN = \"<SOS>\"\n",
+    "EOS_TOKEN = \"<EOS>\"\n",
+    "MASK_TOKEN = \"<MASK>\"\n",
+    "\n",
+    "# Open the large Parquet file (91 GB)\n",
+    "parquet_file = pq.ParquetFile(\"df_massspecgym_processed_full.parquet\")\n",
+    "\n",
+    "start = time.time()\n",
+    "# Step 1: Build vocabulary from all SMILES across row groups\n",
+    "unique_chars = set()\n",
+    "for i in range(parquet_file.num_row_groups):\n",
+    "    table = parquet_file.read_row_group(i, columns=[\"smiles\"])\n",
+    "    df = table.to_pandas()\n",
+    "    unique_chars |= set(''.join(df['smiles'].dropna().astype(str).tolist()))\n",
+    "\n",
+    "# Define vocabulary\n",
+    "valid_atoms = {'C', 'N', 'O', 'S', 'P', 'F', 'Cl', 'Br', 'I', 'H'}\n",
+    "tokens = [PAD_TOKEN, SOS_TOKEN, EOS_TOKEN, MASK_TOKEN] + sorted(unique_chars - {PAD_TOKEN, SOS_TOKEN, EOS_TOKEN, MASK_TOKEN})\n",
+    "token_to_idx = {tok: i for i, tok in enumerate(tokens) if tok in valid_atoms or tok in {PAD_TOKEN, SOS_TOKEN, EOS_TOKEN, MASK_TOKEN, '(', ')', '=', '#', '@', '[', ']', '/', '\\\\', '.', ':'}}\n",
+    "idx_to_token = {i: tok for tok, i in token_to_idx.items()}\n",
+    "vocab_size = len(token_to_idx)\n",
+    "\n",
+    "# Determine supervised max length (longest SMILES + 2 for SOS and EOS)\n",
+    "SUPERVISED_MAX_LEN = 0\n",
+    "for i in range(parquet_file.num_row_groups):\n",
+    "    table = parquet_file.read_row_group(i, columns=[\"smiles\"])\n",
+    "    df = table.to_pandas()\n",
+    "    max_len = max(len(s) for s in df['smiles'].dropna().astype(str))\n",
+    "    SUPERVISED_MAX_LEN = max(SUPERVISED_MAX_LEN, max_len + 2)\n",
+    "\n",
+    "PRETRAIN_MAX_LEN = 100\n",
+    "\n",
+    "print(f\"✅ Vocabulary size: {vocab_size}, Supervised MAX_LEN: {SUPERVISED_MAX_LEN}, Pretrain MAX_LEN: {PRETRAIN_MAX_LEN}\")\n",
+    "print(f\"Completed in {time.time() - start:.2f}s\")\n",
+    "# Step 2: Define encoder function\n",
+    "start = time.time()\n",
+    "def encode_smiles(smiles, max_len=PRETRAIN_MAX_LEN):\n",
+    "    tokens = [SOS_TOKEN] + [c for c in smiles[:max_len - 2] if c in token_to_idx] + [EOS_TOKEN]\n",
+    "    token_ids = [token_to_idx.get(tok, token_to_idx[PAD_TOKEN]) for tok in tokens]\n",
+    "    if len(token_ids) > max_len:\n",
+    "        return token_ids[:max_len]\n",
+    "    else:\n",
+    "        return token_ids + [token_to_idx[PAD_TOKEN]] * (max_len - len(token_ids))\n",
+    "print(f\"Completed in {time.time() - start:.2f}s\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=12)]: Using backend LokyBackend with 12 concurrent workers.\n",
+      "[Parallel(n_jobs=12)]: Done  93 tasks      | elapsed:    0.5s\n",
+      "[Parallel(n_jobs=12)]: Done 1320 tasks      | elapsed:    0.9s\n",
+      "[Parallel(n_jobs=12)]: Done 49128 tasks      | elapsed:    2.5s\n",
+      "[Parallel(n_jobs=12)]: Done 215016 tasks      | elapsed:    7.7s\n",
+      "[Parallel(n_jobs=12)]: Done 417768 tasks      | elapsed:   13.6s\n",
+      "[Parallel(n_jobs=12)]: Done 657384 tasks      | elapsed:   20.5s\n",
+      "[Parallel(n_jobs=12)]: Done 933864 tasks      | elapsed:   28.4s\n",
+      "[Parallel(n_jobs=12)]: Done 1247208 tasks      | elapsed:   37.5s\n",
+      "[Parallel(n_jobs=12)]: Done 1597416 tasks      | elapsed:   47.1s\n",
+      "[Parallel(n_jobs=12)]: Done 1984488 tasks      | elapsed:   57.6s\n",
+      "[Parallel(n_jobs=12)]: Done 2408424 tasks      | elapsed:  1.2min\n",
+      "[Parallel(n_jobs=12)]: Done 2869224 tasks      | elapsed:  1.4min\n",
+      "[Parallel(n_jobs=12)]: Done 3366888 tasks      | elapsed:  1.6min\n",
+      "[Parallel(n_jobs=12)]: Done 3901416 tasks      | elapsed:  1.9min\n",
+      "[Parallel(n_jobs=12)]: Done 4459688 tasks      | elapsed:  2.1min\n",
+      "[Parallel(n_jobs=12)]: Done 4915848 tasks      | elapsed:  2.3min\n",
+      "[Parallel(n_jobs=12)]: Done 5350056 tasks      | elapsed:  2.5min\n",
+      "[Parallel(n_jobs=12)]: Done 5776296 tasks      | elapsed:  2.7min\n",
+      "[Parallel(n_jobs=12)]: Done 6291648 tasks      | elapsed:  3.0min\n",
+      "[Parallel(n_jobs=12)]: Done 6985656 tasks      | elapsed:  3.3min\n",
+      "[Parallel(n_jobs=12)]: Done 7596288 tasks      | elapsed:  3.5min\n",
+      "[Parallel(n_jobs=12)]: Done 8185608 tasks      | elapsed:  3.8min\n",
+      "[Parallel(n_jobs=12)]: Done 8693208 tasks      | elapsed:  4.0min\n",
+      "[Parallel(n_jobs=12)]: Done 9222408 tasks      | elapsed:  4.3min\n",
+      "[Parallel(n_jobs=12)]: Done 9917424 tasks      | elapsed:  4.6min\n",
+      "[Parallel(n_jobs=12)]: Done 10818000 tasks      | elapsed:  5.0min\n",
+      "[Parallel(n_jobs=12)]: Done 11495952 tasks      | elapsed:  5.3min\n",
+      "[Parallel(n_jobs=12)]: Done 12210048 tasks      | elapsed:  5.6min\n",
+      "[Parallel(n_jobs=12)]: Done 13021992 tasks      | elapsed:  6.0min\n",
+      "[Parallel(n_jobs=12)]: Done 14128776 tasks      | elapsed:  6.5min\n",
+      "[Parallel(n_jobs=12)]: Done 15094032 tasks      | elapsed:  7.0min\n",
+      "[Parallel(n_jobs=12)]: Done 16001952 tasks      | elapsed:  7.4min\n",
+      "[Parallel(n_jobs=12)]: Done 16921324 tasks      | elapsed:  7.8min\n",
+      "[Parallel(n_jobs=12)]: Done 17616120 tasks      | elapsed:  8.1min\n",
+      "[Parallel(n_jobs=12)]: Done 18342024 tasks      | elapsed:  8.4min\n",
+      "[Parallel(n_jobs=12)]: Done 19088376 tasks      | elapsed:  8.7min\n",
+      "[Parallel(n_jobs=12)]: Done 19320594 out of 19320594 | elapsed:  8.8min finished\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Done in 667.19s — 19320594 fingerprints saved to all_morgan_fingerprints.pkl\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Precompute Morgan fingerprints\n",
+    "import pandas as pd\n",
+    "import pyarrow.parquet as pq\n",
+    "from rdkit import Chem\n",
+    "from rdkit.Chem import rdFingerprintGenerator\n",
+    "from joblib import Parallel, delayed\n",
+    "import pickle\n",
+    "import time\n",
+    "\n",
+    "start = time.time()\n",
+    "\n",
+    "# Load df_massspecgym from large Parquet file (only SMILES column)\n",
+    "massspec_parquet = pq.ParquetFile(\"df_massspecgym_processed_full.parquet\")\n",
+    "df_massspecgym = pd.concat([\n",
+    "    massspec_parquet.read_row_group(i, columns=[\"smiles\"]).to_pandas()\n",
+    "    for i in range(massspec_parquet.num_row_groups)\n",
+    "], ignore_index=True)\n",
+    "\n",
+    "# Load df_external from smaller Parquet file\n",
+    "df_external = pd.read_parquet(\"df_external_processed.parquet\")\n",
+    "\n",
+    "# Combine and deduplicate SMILES\n",
+    "all_smiles = list(set(df_massspecgym['smiles'].dropna().tolist() + df_external['smiles'].dropna().tolist()))\n",
+    "\n",
+    "# Function that avoids unpicklable generator\n",
+    "def fingerprint_one(smiles):\n",
+    "    try:\n",
+    "        mol = Chem.MolFromSmiles(smiles)\n",
+    "        if mol is not None:\n",
+    "            generator = rdFingerprintGenerator.GetMorganGenerator(radius=2, fpSize=2048)\n",
+    "            return smiles, generator.GetFingerprint(mol)\n",
+    "    except Exception as e:\n",
+    "        print(f\"Failed: {smiles} → {e}\")\n",
+    "    return smiles, None\n",
+    "\n",
+    "# Run parallel computation with 12 CPUs\n",
+    "results = Parallel(n_jobs=12, verbose=5)(\n",
+    "    delayed(fingerprint_one)(s) for s in all_smiles\n",
+    ")\n",
+    "\n",
+    "# Collect into dictionary\n",
+    "all_fingerprints = {s: fp for s, fp in results if fp is not None}\n",
+    "\n",
+    "# Save to file\n",
+    "with open(\"all_morgan_fingerprints.pkl\", \"wb\") as f:\n",
+    "    pickle.dump(all_fingerprints, f)\n",
+    "\n",
+    "print(f\"✅ Done in {time.time() - start:.2f}s — {len(all_fingerprints)} fingerprints saved to all_morgan_fingerprints.pkl\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Dataset class\n",
+    "class MSMSDataset(Dataset):\n",
+    "    def __init__(self, dataframe, max_len=PRETRAIN_MAX_LEN, is_ssl=False):\n",
+    "        self.spectra = np.stack(dataframe['binned'].values)\n",
+    "        self.graph_data = dataframe['graph_data'].values\n",
+    "        self.ion_modes = dataframe['ion_mode'].values\n",
+    "        self.precursor_bins = dataframe['precursor_bin'].values\n",
+    "        self.adduct_indices = dataframe['adduct_idx'].values\n",
+    "        self.raw_smiles = dataframe['smiles'].values\n",
+    "        self.is_ssl = is_ssl\n",
+    "        if is_ssl:\n",
+    "            self.smiles = []\n",
+    "            self.masked_smiles = []\n",
+    "            for s in self.raw_smiles:\n",
+    "                masked_s, orig_s = self.mask_smiles(s)\n",
+    "                self.smiles.append(encode_smiles(orig_s, max_len))\n",
+    "                self.masked_smiles.append(encode_smiles(masked_s, max_len))\n",
+    "        else:\n",
+    "            self.smiles = [encode_smiles(s, max_len=SUPERVISED_MAX_LEN) for s in self.raw_smiles]\n",
+    "\n",
+    "    def mask_smiles(self, smiles, mask_ratio=0.10):\n",
+    "        chars = list(smiles)[:PRETRAIN_MAX_LEN-2]\n",
+    "        masked_chars = chars.copy()\n",
+    "        n_mask = int(mask_ratio * len(chars))\n",
+    "        mask_indices = np.random.choice(len(chars), n_mask, replace=False)\n",
+    "        for idx in mask_indices:\n",
+    "            masked_chars[idx] = MASK_TOKEN\n",
+    "        return ''.join(masked_chars), ''.join(chars)\n",
+    "\n",
+    "    def __len__(self):\n",
+    "        return len(self.spectra)\n",
+    "\n",
+    "    def __getitem__(self, idx):\n",
+    "        if self.is_ssl:\n",
+    "            return (\n",
+    "                torch.tensor(self.spectra[idx], dtype=torch.float),\n",
+    "                self.graph_data[idx],\n",
+    "                torch.tensor(self.smiles[idx], dtype=torch.long),\n",
+    "                torch.tensor(self.masked_smiles[idx], dtype=torch.long),\n",
+    "                torch.tensor(self.ion_modes[idx], dtype=torch.long),\n",
+    "                torch.tensor(self.precursor_bins[idx], dtype=torch.long),\n",
+    "                torch.tensor(self.adduct_indices[idx], dtype=torch.long),\n",
+    "                self.raw_smiles[idx]\n",
+    "            )\n",
+    "        return (\n",
+    "            torch.tensor(self.spectra[idx], dtype=torch.float),\n",
+    "            self.graph_data[idx],\n",
+    "            torch.tensor(self.smiles[idx], dtype=torch.long),\n",
+    "            torch.tensor(self.ion_modes[idx], dtype=torch.long),\n",
+    "            torch.tensor(self.precursor_bins[idx], dtype=torch.long),\n",
+    "            torch.tensor(self.adduct_indices[idx], dtype=torch.long),\n",
+    "            self.raw_smiles[idx]\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Positional Encoding\n",
+    "class PositionalEncoding(nn.Module):\n",
+    "    def __init__(self, d_model, max_len=1000):\n",
+    "        super().__init__()\n",
+    "        pe = torch.zeros(max_len, d_model)\n",
+    "        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)\n",
+    "        div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))\n",
+    "        pe[:, 0::2] = torch.sin(position * div_term)\n",
+    "        pe[:, 1::2] = torch.cos(position * div_term)\n",
+    "        pe = pe.unsqueeze(0)\n",
+    "        self.register_buffer('pe', pe)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return x + self.pe[:, :x.size(1), :]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Transformer Encoder\n",
+    "class SpectrumTransformerEncoder(nn.Module):\n",
+    "    def __init__(self, input_dim=1000, d_model=768, nhead=12, num_layers=8, dim_feedforward=2048, dropout=0.2):\n",
+    "        super().__init__()\n",
+    "        self.input_proj = nn.Linear(input_dim, d_model)\n",
+    "        self.metadata_emb = nn.Linear(2 + 32, 64)\n",
+    "        self.pos_encoder = PositionalEncoding(d_model)\n",
+    "        encoder_layer = nn.TransformerEncoderLayer(d_model, nhead, dim_feedforward, dropout, batch_first=True)\n",
+    "        self.transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers)\n",
+    "        self.norm = nn.LayerNorm(d_model)\n",
+    "        self.fc = nn.Linear(d_model + 64, d_model // 2)\n",
+    "        self.adduct_emb = nn.Embedding(len(adduct_types), 32)\n",
+    "\n",
+    "    def forward(self, src, ion_mode_idx, precursor_idx, adduct_idx):\n",
+    "        src = self.input_proj(src).unsqueeze(1)\n",
+    "        adduct_embed = self.adduct_emb(adduct_idx)\n",
+    "        metadata = self.metadata_emb(torch.cat([ion_mode_idx.unsqueeze(-1).float(), precursor_idx.unsqueeze(-1).float(), adduct_embed], dim=-1))\n",
+    "        src = self.pos_encoder(src)\n",
+    "        output = self.transformer_encoder(src).squeeze(1)\n",
+    "        output = self.norm(output)\n",
+    "        output = torch.cat([output, metadata], dim=-1)\n",
+    "        output = self.fc(output)\n",
+    "        return output, self.transformer_encoder.layers[-1].self_attn(src, src, src)[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GNN Encoder with Expanded Substructures\n",
+    "class SpectrumGNNEncoder(MessagePassing):\n",
+    "    def __init__(self, d_model=768, hidden_dim=256, num_layers=3, dropout=0.2):\n",
+    "        super().__init__(aggr='mean')\n",
+    "        self.d_model = d_model\n",
+    "        self.num_layers = num_layers\n",
+    "        self.input_proj = nn.Linear(1, hidden_dim)\n",
+    "        self.message_nets = nn.ModuleList([nn.Linear(2 * hidden_dim, hidden_dim) for _ in range(num_layers)])\n",
+    "        self.update_nets = nn.ModuleList([nn.Linear(2 * hidden_dim, hidden_dim) for _ in range(num_layers)])\n",
+    "        self.metadata_emb = nn.Linear(2 + 32, hidden_dim)\n",
+    "        self.norm = nn.LayerNorm(hidden_dim)\n",
+    "        self.output_layer = nn.Linear(hidden_dim, d_model // 2)\n",
+    "        self.dropout = nn.Dropout(dropout)\n",
+    "        self.substructure_head = nn.Linear(hidden_dim, 30)  # 30 substructures\n",
+    "        self.adduct_emb = nn.Embedding(len(adduct_types), 32)\n",
+    "        self.substructures = ['C=O', 'C=C', 'c1ccccc1', 'C#N', 'C(=O)O', 'N=O', 'S=O', 'P=O', 'C#C', 'C-N-C',\n",
+    "                              'C-O-C', 'C-S-C', 'C(=O)N', 'C(=O)S', 'C=C-C', 'c1ccncc1', 'c1cncnc1', 'c1ccoc1',\n",
+    "                              'c1ccsc1', 'C(=O)C', 'N-C-N', 'S-C-S', 'P-C-P', 'C-F', 'C-Cl', 'C-Br', 'C-I', 'N-N',\n",
+    "                              'O-O', 'S-S']\n",
+    "\n",
+    "    def forward(self, graph_data, ion_mode_idx, precursor_idx, adduct_idx):\n",
+    "        batch = Batch.from_data_list(graph_data).to(device)\n",
+    "        x, edge_index = batch.x, batch.edge_index\n",
+    "        ion_mode = batch.ion_mode\n",
+    "        precursor_mz = batch.precursor_mz\n",
+    "        adduct_embed = self.adduct_emb(adduct_idx)\n",
+    "\n",
+    "        x = self.input_proj(x)\n",
+    "        metadata = self.metadata_emb(torch.cat([ion_mode.unsqueeze(-1), precursor_mz.unsqueeze(-1), adduct_embed], dim=-1))\n",
+    "\n",
+    "        edge_weights = []\n",
+    "        for i in range(self.num_layers):\n",
+    "            self._propagate_layer = i\n",
+    "            x_before = x.clone()\n",
+    "            x = self.propagate(edge_index, x=x)\n",
+    "            x = self.update_nets[i](torch.cat([x, metadata], dim=-1))\n",
+    "            x = self.norm(x)\n",
+    "            x = F.relu(x)\n",
+    "            x = self.dropout(x)\n",
+    "            edge_weights.append((x - x_before).norm(dim=-1))\n",
+    "\n",
+    "        x = global_mean_pool(x, batch.batch)\n",
+    "        substructure_pred = self.substructure_head(x)\n",
+    "        x = self.output_layer(x)\n",
+    "        return x, substructure_pred, edge_weights\n",
+    "\n",
+    "    def message(self, x_i, x_j):\n",
+    "        return F.relu(self.message_nets[self._propagate_layer](torch.cat([x_i, x_j], dim=-1)))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Novel Decoder with Stereochemistry and Substructure Guidance\n",
+    "class SmilesTransformerDecoder(nn.Module):\n",
+    "    def __init__(self, vocab_size, d_model=768, nhead=12, num_layers=8, dim_feedforward=2048, dropout=0.2):\n",
+    "        super().__init__()\n",
+    "        self.embedding = nn.Embedding(vocab_size, d_model)\n",
+    "        self.pos_encoder = PositionalEncoding(d_model)\n",
+    "        decoder_layer = nn.TransformerDecoderLayer(d_model, nhead, dim_feedforward, dropout, batch_first=True)\n",
+    "        self.transformer_decoder = nn.TransformerDecoder(decoder_layer, num_layers)\n",
+    "        self.norm = nn.LayerNorm(d_model)\n",
+    "        self.output_layer = nn.Linear(d_model, vocab_size)\n",
+    "        self.d_model = d_model\n",
+    "        self.valence_rules = {\n",
+    "            'C': 4, 'N': 3, 'O': 2, 'S': 2, 'P': 3, 'F': 1, 'Cl': 1, 'Br': 1, 'I': 1, 'H': 1\n",
+    "        }\n",
+    "        self.stereo_tokens = {'@', '/'}\n",
+    "        self.substructure_condition = nn.Linear(30, d_model)\n",
+    "\n",
+    "    def compute_valence(self, smiles_tokens, batch_size):\n",
+    "        valence_counts = torch.zeros(batch_size, len(self.valence_rules)).to(smiles_tokens.device)\n",
+    "        atom_indices = {tok: i for i, tok in enumerate(self.valence_rules.keys())}\n",
+    "        bond_counts = torch.zeros(batch_size, device=smiles_tokens.device)\n",
+    "        for t in range(smiles_tokens.size(1)):\n",
+    "            for tok, idx in atom_indices.items():\n",
+    "                mask = smiles_tokens[:, t] == token_to_idx[tok]\n",
+    "                valence_counts[mask, idx] += self.valence_rules[tok]\n",
+    "            for tok in ['=', '#']:\n",
+    "                mask = smiles_tokens[:, t] == token_to_idx[tok]\n",
+    "                bond_counts[mask] += 2 if tok == '#' else 1\n",
+    "        valence_counts = valence_counts - bond_counts.unsqueeze(-1)\n",
+    "        return torch.relu(valence_counts - torch.tensor(list(self.valence_rules.values()), device=smiles_tokens.device)).sum(dim=-1)\n",
+    "\n",
+    "    def forward(self, tgt, memory, substructure_pred, tgt_mask=None, memory_key_padding_mask=None):\n",
+    "        embedded = self.embedding(tgt) * math.sqrt(self.d_model)\n",
+    "        embedded = self.pos_encoder(embedded)\n",
+    "        substructure_emb = self.substructure_condition(substructure_pred).unsqueeze(1)\n",
+    "        embedded = embedded + substructure_emb\n",
+    "        output = self.transformer_decoder(embedded, memory, tgt_mask, memory_key_padding_mask)\n",
+    "        output = self.norm(output)\n",
+    "        logits = self.output_layer(output)\n",
+    "        valence_penalty = self.compute_valence(tgt, tgt.size(0))\n",
+    "        return logits, valence_penalty"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Full Model with RL Component\n",
+    "class MSMS2SmilesHybrid(nn.Module):\n",
+    "    def __init__(self, vocab_size, d_model=768, nhead=12, num_layers=8, dim_feedforward=2048, dropout=0.2, fp_size=2048):\n",
+    "        super().__init__()\n",
+    "        self.transformer_encoder = SpectrumTransformerEncoder(input_dim=1000, d_model=d_model, nhead=nhead, num_layers=num_layers, dim_feedforward=dim_feedforward, dropout=dropout)\n",
+    "        self.gnn_encoder = SpectrumGNNEncoder(d_model=d_model, hidden_dim=256, num_layers=3, dropout=dropout)\n",
+    "        self.decoder = SmilesTransformerDecoder(vocab_size, d_model, nhead, num_layers, dim_feedforward, dropout)\n",
+    "        self.combine_layer = nn.Linear(d_model, d_model)\n",
+    "        self.fp_head = nn.Linear(d_model, fp_size)\n",
+    "        self.fp_size = fp_size\n",
+    "        self.log_sigma_smiles = nn.Parameter(torch.zeros(1))\n",
+    "        self.log_sigma_fp = nn.Parameter(torch.zeros(1))\n",
+    "        self.log_sigma_sub = nn.Parameter(torch.zeros(1))\n",
+    "\n",
+    "    def generate_square_subsequent_mask(self, tgt_len):\n",
+    "        mask = torch.triu(torch.ones(tgt_len, tgt_len), diagonal=1)\n",
+    "        mask = mask.float().masked_fill(mask == 1, float('-inf')).masked_fill(mask == 0, float(0.0))\n",
+    "        return mask\n",
+    "\n",
+    "    def forward(self, spectrum, graph_data, tgt, ion_mode_idx, precursor_idx, adduct_idx, tgt_mask=None, memory_key_padding_mask=None):\n",
+    "        trans_output, attn_weights = self.transformer_encoder(spectrum, ion_mode_idx, precursor_idx, adduct_idx)\n",
+    "        gnn_output, substructure_pred, edge_weights = self.gnn_encoder(graph_data, ion_mode_idx, precursor_idx, adduct_idx)\n",
+    "        memory = self.combine_layer(torch.cat([trans_output, gnn_output], dim=-1)).unsqueeze(1)\n",
+    "        smiles_output, valence_penalty = self.decoder(tgt, memory, substructure_pred, tgt_mask, memory_key_padding_mask)\n",
+    "        fp_output = self.fp_head(memory.squeeze(1))\n",
+    "        return smiles_output, fp_output, valence_penalty, attn_weights, edge_weights, substructure_pred"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SSL Pretraining\n",
+    "def ssl_pretrain(model, dataloader, epochs=3, lr=1e-4):\n",
+    "    model.train()\n",
+    "    scaler = GradScaler()\n",
+    "    optimizer = optim.Adam(model.parameters(), lr=lr)\n",
+    "    criterion = nn.CrossEntropyLoss(ignore_index=token_to_idx[PAD_TOKEN])\n",
+    "    for epoch in range(epochs):\n",
+    "        total_loss = 0\n",
+    "        for spectra, graph_data, smiles_tokens, masked_tokens, ion_modes, precursor_bins, adduct_indices, _ in tqdm(dataloader, desc=f\"SSL Epoch {epoch+1}/{epochs}\"):\n",
+    "            spectra = spectra.to(device)\n",
+    "            ion_modes = ion_modes.to(device)\n",
+    "            precursor_bins = precursor_bins.to(device)\n",
+    "            adduct_indices = adduct_indices.to(device)\n",
+    "            smiles_tokens = smiles_tokens.to(device)\n",
+    "            masked_tokens = masked_tokens.to(device)\n",
+    "            tgt_input = masked_tokens[:, :-1]\n",
+    "            tgt_output = smiles_tokens[:, 1:]\n",
+    "            tgt_mask = model.generate_square_subsequent_mask(tgt_input.size(1)).to(device)\n",
+    "            optimizer.zero_grad()\n",
+    "            with autocast():\n",
+    "                smiles_output, _, valence_penalty, _, _, _ = model(spectra, graph_data, tgt_input, ion_modes, precursor_bins, adduct_indices, tgt_mask)\n",
+    "                loss = criterion(smiles_output.reshape(-1, vocab_size), tgt_output.reshape(-1)) + 0.1 * valence_penalty.mean()\n",
+    "            scaler.scale(loss).backward()\n",
+    "            scaler.step(optimizer)\n",
+    "            scaler.update()\n",
+    "            total_loss += loss.item()\n",
+    "        avg_loss = total_loss / len(dataloader)\n",
+    "        print(f\"SSL Epoch {epoch+1}/{epochs} - Loss: {avg_loss:.4f}\")\n",
+    "        torch.save({\n",
+    "            'epoch': epoch + 1,\n",
+    "            'model_state_dict': model.state_dict(),\n",
+    "            'optimizer_state_dict': optimizer.state_dict(),\n",
+    "            'loss': avg_loss\n",
+    "        }, f'ssl_checkpoint_epoch_{epoch+1}.pt')\n",
+    "        print(f\"Saved SSL checkpoint: ssl_checkpoint_epoch_{epoch+1}.pt\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Supervised Training with RL\n",
+    "def supervised_train(model, train_loader, val_loader, epochs=30, lr=1e-4, patience=5):\n",
+    "    model.train()\n",
+    "    scaler = GradScaler()\n",
+    "    optimizer = optim.Adam(model.parameters(), lr=lr)\n",
+    "    scheduler = optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode='min', factor=0.5, patience=2)\n",
+    "    smiles_criterion = nn.CrossEntropyLoss(ignore_index=token_to_idx[PAD_TOKEN])\n",
+    "    fp_criterion = nn.BCEWithLogitsLoss()\n",
+    "    mw_criterion = nn.MSELoss()\n",
+    "    sub_criterion = nn.BCEWithLogitsLoss()\n",
+    "    best_val_loss = float('inf')\n",
+    "    no_improve = 0\n",
+    "\n",
+    "    for epoch in range(epochs):\n",
+    "        model.train()\n",
+    "        total_train_loss = 0\n",
+    "        for spectra, graph_data, smiles_tokens, ion_modes, precursor_bins, adduct_indices, raw_smiles in tqdm(train_loader, desc=f\"Epoch {epoch+1}/{epochs}\"):\n",
+    "            spectra = spectra.to(device)\n",
+    "            ion_modes = ion_modes.to(device)\n",
+    "            precursor_bins = precursor_bins.to(device)\n",
+    "            adduct_indices = adduct_indices.to(device)\n",
+    "            smiles_tokens = smiles_tokens.to(device)\n",
+    "            tgt_input = smiles_tokens[:, :-1]\n",
+    "            tgt_output = smiles_tokens[:, 1:]\n",
+    "            tgt_mask = model.generate_square_subsequent_mask(tgt_input.size(1)).to(device)\n",
+    "            optimizer.zero_grad()\n",
+    "            with autocast():\n",
+    "                smiles_output, fp_output, valence_penalty, _, _, substructure_pred = model(spectra, graph_data, tgt_input, ion_modes, precursor_bins, adduct_indices, tgt_mask)\n",
+    "                smiles_loss = smiles_criterion(smiles_output.reshape(-1, vocab_size), tgt_output.reshape(-1))\n",
+    "                fp_loss = 0\n",
+    "                mw_loss = 0\n",
+    "                sub_loss = 0\n",
+    "                valid_count = 0\n",
+    "                substructure_targets = torch.zeros(len(raw_smiles), 30, dtype=torch.float, device=device)\n",
+    "                for i, (smiles, fp) in enumerate(zip(raw_smiles, fp_output)):\n",
+    "                    mol = Chem.MolFromSmiles(smiles, sanitize=True)\n",
+    "                    if mol:\n",
+    "                        true_fp = morgan_gen.GetFingerprint(mol)\n",
+    "                        fp_loss += fp_criterion(fp, torch.tensor([int(b) for b in true_fp.ToBitString()], dtype=torch.float, device=device))\n",
+    "                        mw_loss += mw_criterion(torch.tensor(Descriptors.MolWt(mol), dtype=torch.float, device=device), torch.tensor(500.0, dtype=torch.float, device=device))\n",
+    "                        for j, smarts in enumerate(model.gnn_encoder.substructures):\n",
+    "                            if mol.HasSubstructMatch(Chem.MolFromSmarts(smarts)):\n",
+    "                                substructure_targets[i, j] = 1\n",
+    "                        valid_count += 1\n",
+    "                fp_loss = fp_loss / valid_count if valid_count > 0 else torch.tensor(0.0, device=device)\n",
+    "                mw_loss = mw_loss / valid_count if valid_count > 0 else torch.tensor(0.0, device=device)\n",
+    "                sub_loss = sub_criterion(substructure_pred, substructure_targets)\n",
+    "                sigma_smiles = torch.clamp(torch.exp(model.log_sigma_smiles), 0.1, 10.0)\n",
+    "                sigma_fp = torch.clamp(torch.exp(model.log_sigma_fp), 0.1, 10.0)\n",
+    "                sigma_sub = torch.clamp(torch.exp(model.log_sigma_sub), 0.1, 10.0)\n",
+    "                supervised_loss = (smiles_loss / (2 * sigma_smiles**2) + model.log_sigma_smiles) + \\\n",
+    "                                 (0.1 * fp_loss / (2 * sigma_fp**2) + model.log_sigma_fp) + \\\n",
+    "                                 (0.1 * sub_loss / (2 * sigma_sub**2) + model.log_sigma_sub) + \\\n",
+    "                                 0.1 * valence_penalty.mean() + 0.1 * mw_loss\n",
+    "                # RL component: Tanimoto reward\n",
+    "                rl_loss = 0\n",
+    "                if epoch >= 5:  # Start RL after initial training\n",
+    "                    pred_smiles = beam_search(model, spectra[0], graph_data[0], ion_modes[0], precursor_bins[0], adduct_indices[0], raw_smiles[0], beam_width=5, max_len=SUPERVISED_MAX_LEN, device=device)\n",
+    "                    if pred_smiles[0][0] != \"Invalid SMILES\":\n",
+    "                        tanimoto = tanimoto_similarity(pred_smiles[0][0], raw_smiles[0], all_fingerprints)\n",
+    "                        rl_loss = -torch.log(torch.tensor(tanimoto + 1e-6, device=device))\n",
+    "                loss = supervised_loss + 0.1 * rl_loss\n",
+    "            scaler.scale(loss).backward()\n",
+    "            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)\n",
+    "            scaler.step(optimizer)\n",
+    "            scaler.update()\n",
+    "            total_train_loss += loss.item()\n",
+    "        avg_train_loss = total_train_loss / len(train_loader)\n",
+    "\n",
+    "        # Validation\n",
+    "        model.eval()\n",
+    "        total_val_loss = 0\n",
+    "        with torch.no_grad():\n",
+    "            for spectra, graph_data, smiles_tokens, ion_modes, precursor_bins, adduct_indices, raw_smiles in val_loader:\n",
+    "                spectra = spectra.to(device)\n",
+    "                ion_modes = ion_modes.to(device)\n",
+    "                precursor_bins = precursor_bins.to(device)\n",
+    "                adduct_indices = adduct_indices.to(device)\n",
+    "                smiles_tokens = smiles_tokens.to(device)\n",
+    "                tgt_input = smiles_tokens[:, :-1]\n",
+    "                tgt_output = smiles_tokens[:, 1:]\n",
+    "                tgt_mask = model.generate_square_subsequent_mask(tgt_input.size(1)).to(device)\n",
+    "                with autocast():\n",
+    "                    smiles_output, fp_output, valence_penalty, _, _, substructure_pred = model(spectra, graph_data, tgt_input, ion_modes, precursor_bins, adduct_indices, tgt_mask)\n",
+    "                    smiles_loss = smiles_criterion(smiles_output.reshape(-1, vocab_size), tgt_output.reshape(-1))\n",
+    "                    fp_loss = 0\n",
+    "                    mw_loss = 0\n",
+    "                    sub_loss = 0\n",
+    "                    valid_count = 0\n",
+    "                    substructure_targets = torch.zeros(len(raw_smiles), 30, dtype=torch.float, device=device)\n",
+    "                    for i, (smiles, fp) in enumerate(zip(raw_smiles, fp_output)):\n",
+    "                        mol = Chem.MolFromSmiles(smiles, sanitize=True)\n",
+    "                        if mol:\n",
+    "                            true_fp = morgan_gen.GetFingerprint(mol)\n",
+    "                            fp_loss += fp_criterion(fp, torch.tensor([int(b) for b in true_fp.ToBitString()], dtype=torch.float, device=device))\n",
+    "                            mw_loss += mw_criterion(torch.tensor(Descriptors.MolWt(mol), dtype=torch.float, device=device), torch.tensor(500.0, dtype=torch.float, device=device))\n",
+    "                            for j, smarts in enumerate(model.gnn_encoder.substructures):\n",
+    "                                if mol.HasSubstructMatch(Chem.MolFromSmarts(smarts)):\n",
+    "                                    substructure_targets[i, j] = 1\n",
+    "                            valid_count += 1\n",
+    "                    fp_loss = fp_loss / valid_count if valid_count > 0 else torch.tensor(0.0, device=device)\n",
+    "                    mw_loss = mw_loss / valid_count if valid_count > 0 else torch.tensor(0.0, device=device)\n",
+    "                    sub_loss = sub_criterion(substructure_pred, substructure_targets)\n",
+    "                    sigma_smiles = torch.clamp(torch.exp(model.log_sigma_smiles), 0.1, 10.0)\n",
+    "                    sigma_fp = torch.clamp(torch.exp(model.log_sigma_fp), 0.1, 10.0)\n",
+    "                    sigma_sub = torch.clamp(torch.exp(model.log_sigma_sub), 0.1, 10.0)\n",
+    "                    loss = (smiles_loss / (2 * sigma_smiles**2) + model.log_sigma_smiles) + \\\n",
+    "                           (0.1 * fp_loss / (2 * sigma_fp**2) + model.log_sigma_fp) + \\\n",
+    "                           (0.1 * sub_loss / (2 * sigma_sub**2) + model.log_sigma_sub) + \\\n",
+    "                           0.1 * valence_penalty.mean() + 0.1 * mw_loss\n",
+    "                total_val_loss += loss.item()\n",
+    "        avg_val_loss = total_val_loss / len(val_loader)\n",
+    "\n",
+    "        print(f\"Epoch {epoch+1}/{epochs} - Train Loss: {avg_train_loss:.4f}, Val Loss: {avg_val_loss:.4f}, LR: {optimizer.param_groups[0]['lr']:.6f}\")\n",
+    "        scheduler.step(avg_val_loss)\n",
+    "\n",
+    "        if (epoch + 1) % 10 == 0:\n",
+    "            checkpoint_path = f'checkpoint_epoch_{epoch+1}.pt'\n",
+    "            torch.save({\n",
+    "                'epoch': epoch + 1,\n",
+    "                'model_state_dict': model.state_dict(),\n",
+    "                'optimizer_state_dict': optimizer.state_dict(),\n",
+    "                'scheduler_state_dict': scheduler.state_dict(),\n",
+    "                'val_loss': avg_val_loss,\n",
+    "                'token_to_idx': token_to_idx,\n",
+    "                'idx_to_token': idx_to_token\n",
+    "            }, checkpoint_path)\n",
+    "            print(f\"Saved checkpoint: {checkpoint_path}\")\n",
+    "\n",
+    "        if avg_val_loss < best_val_loss:\n",
+    "            best_val_loss = avg_val_loss\n",
+    "            no_improve = 0\n",
+    "            torch.save({\n",
+    "                'model_state_dict': model.state_dict(),\n",
+    "                'token_to_idx': token_to_idx,\n",
+    "                'idx_to_token': idx_to_token\n",
+    "            }, 'best_msms_hybrid.pt')\n",
+    "        else:\n",
+    "            no_improve += 1\n",
+    "        if no_improve >= patience:\n",
+    "            print(f\"Early stopping at epoch {epoch+1}\")\n",
+    "            break\n",
+    "\n",
+    "    return best_val_loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SMILES Syntax Validator\n",
+    "def is_valid_smiles_syntax(smiles):\n",
+    "    stack = []\n",
+    "    for c in smiles:\n",
+    "        if c in '([':\n",
+    "            stack.append(c)\n",
+    "        elif c == ')':\n",
+    "            if not stack or stack[-1] != '(':\n",
+    "                return False\n",
+    "            stack.pop()\n",
+    "        elif c == ']':\n",
+    "            if not stack or stack[-1] != '[':\n",
+    "                return False\n",
+    "            stack.pop()\n",
+    "    if stack:\n",
+    "        return False\n",
+    "    i = 0\n",
+    "    while i < len(smiles):\n",
+    "        if smiles[i] == '[':\n",
+    "            j = smiles.find(']', i)\n",
+    "            if j == -1:\n",
+    "                return False\n",
+    "            atom = smiles[i+1:j]\n",
+    "            if not any(a in atom for a in valid_atoms):\n",
+    "                return False\n",
+    "            i = j + 1\n",
+    "        else:\n",
+    "            if smiles[i] in valid_atoms or smiles[i] in '()=#/\\\\@.:':\n",
+    "                i += 1\n",
+    "            else:\n",
+    "                return False\n",
+    "    try:\n",
+    "        mol = Chem.MolFromSmiles(smiles, sanitize=True)\n",
+    "        return mol is not None\n",
+    "    except:\n",
+    "        return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# RDKit-based Molecular Property Filter\n",
+    "def is_plausible_molecule(smiles, true_mol, max_mw=1500, min_logp=-7, max_logp=7):\n",
+    "    mol = Chem.MolFromSmiles(smiles, sanitize=True)\n",
+    "    if not mol or not is_valid_smiles_syntax(smiles):\n",
+    "        return False\n",
+    "    mw = Descriptors.MolWt(mol)\n",
+    "    logp = Descriptors.MolLogP(mol)\n",
+    "    true_mw = Descriptors.MolWt(true_mol) if true_mol else 500\n",
+    "    return mw <= max_mw and min_logp <= logp <= max_logp and abs(mw - true_mw) < 300\n",
+    "\n",
+    "# Evaluation Metrics\n",
+    "def dice_similarity(smiles1, smiles2):\n",
+    "    mol1 = Chem.MolFromSmiles(smiles1)\n",
+    "    mol2 = Chem.MolFromSmiles(smiles2)\n",
+    "    if mol1 and mol2:\n",
+    "        fp1 = morgan_gen.GetFingerprint(mol1)\n",
+    "        fp2 = morgan_gen.GetFingerprint(mol2)\n",
+    "        return DataStructs.DiceSimilarity(fp1, fp2)\n",
+    "    return 0.0\n",
+    "\n",
+    "def mcs_similarity(true_smiles, pred_smiles):\n",
+    "    mol1 = Chem.MolFromSmiles(true_smiles)\n",
+    "    mol2 = Chem.MolFromSmiles(pred_smiles)\n",
+    "    if mol1 and mol2:\n",
+    "        mcs = rdFMCS.FindMCS([mol1, mol2], timeout=30)\n",
+    "        return mcs.numAtoms / max(mol1.GetNumAtoms(), mol2.GetNumAtoms())\n",
+    "    return 0.0\n",
+    "\n",
+    "def mw_difference(true_smiles, pred_smiles):\n",
+    "    mol1 = Chem.MolFromSmiles(true_smiles)\n",
+    "    mol2 = Chem.MolFromSmiles(pred_smiles)\n",
+    "    if mol1 and mol2:\n",
+    "        return abs(Descriptors.MolWt(mol1) - Descriptors.MolWt(mol2))\n",
+    "    return float('inf')\n",
+    "\n",
+    "def logp_difference(true_smiles, pred_smiles):\n",
+    "    mol1 = Chem.MolFromSmiles(true_smiles)\n",
+    "    mol2 = Chem.MolFromSmiles(pred_smiles)\n",
+    "    if mol1 and mol2:\n",
+    "        return abs(Descriptors.MolLogP(mol1) - Descriptors.MolLogP(mol2))\n",
+    "    return float('inf')\n",
+    "\n",
+    "def substructure_match(true_smiles, pred_smiles, substructures):\n",
+    "    mol1 = Chem.MolFromSmiles(true_smiles)\n",
+    "    mol2 = Chem.MolFromSmiles(pred_smiles)\n",
+    "    if not mol1 or not mol2:\n",
+    "        return 0\n",
+    "    matches = 0\n",
+    "    for smarts in substructures:\n",
+    "        pattern = Chem.MolFromSmarts(smarts)\n",
+    "        if mol1.HasSubstructMatch(pattern) and mol2.HasSubstructMatch(pattern):\n",
+    "            matches += 1\n",
+    "    return matches / len(substructures)\n",
+    "\n",
+    "def validity_rate(pred_smiles_list):\n",
+    "    valid = sum(1 for smiles in pred_smiles_list if Chem.MolFromSmiles(smiles, sanitize=True) is not None)\n",
+    "    return valid / len(pred_smiles_list) * 100\n",
+    "\n",
+    "def tanimoto_similarity(smiles1, smiles2, precomputed_fps=None):\n",
+    "    mol1 = Chem.MolFromSmiles(smiles1, sanitize=True)\n",
+    "    if not mol1:\n",
+    "        return 0.0\n",
+    "    fp1 = morgan_gen.GetFingerprint(mol1)\n",
+    "    if precomputed_fps and smiles2 in precomputed_fps:\n",
+    "        fp2 = precomputed_fps[smiles2]\n",
+    "    else:\n",
+    "        mol2 = Chem.MolFromSmiles(smiles2, sanitize=True)\n",
+    "        if not mol2:\n",
+    "            return 0.0\n",
+    "        fp2 = morgan_gen.GetFingerprint(mol2)\n",
+    "    return DataStructs.TanimotoSimilarity(fp1, fp2)\n",
+    "\n",
+    "def prediction_diversity(pred_smiles_list):\n",
+    "    if len(pred_smiles_list) < 2:\n",
+    "        return 0.0\n",
+    "    total_tanimoto = 0\n",
+    "    count = 0\n",
+    "    for i in range(len(pred_smiles_list)):\n",
+    "        for j in range(i+1, len(pred_smiles_list)):\n",
+    "            total_tanimoto += tanimoto_similarity(pred_smiles_list[i], pred_smiles_list[j])\n",
+    "            count += 1\n",
+    "    return 1 - (total_tanimoto / count) if count > 0 else 0.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Beam Search with Stereochemistry\n",
+    "def beam_search(model, spectrum, graph_data, ion_mode_idx, precursor_idx, adduct_idx, true_smiles, beam_width=10, max_len=150, nucleus_p=0.9, device='cpu'):\n",
+    "    model.eval()\n",
+    "    true_mol = Chem.MolFromSmiles(true_smiles) if true_smiles else None\n",
+    "    with torch.no_grad():\n",
+    "        spectrum = spectrum.unsqueeze(0).to(device)\n",
+    "        graph_data = Batch.from_data_list([graph_data]).to(device)\n",
+    "        ion_mode_idx = torch.tensor([ion_mode_idx], dtype=torch.long).to(device)\n",
+    "        precursor_idx = torch.tensor([precursor_idx], dtype=torch.long).to(device)\n",
+    "        adduct_idx = torch.tensor([adduct_idx], dtype=torch.long).to(device)\n",
+    "        memory = model.transformer_encoder(spectrum, ion_mode_idx, precursor_idx, adduct_idx)[0]\n",
+    "        gnn_output, substructure_pred, _ = model.gnn_encoder(graph_data, ion_mode_idx, precursor_idx, adduct_idx)\n",
+    "        memory = model.combine_layer(torch.cat([memory, gnn_output], dim=-1)).unsqueeze(1)\n",
+    "        sequences = [([token_to_idx[SOS_TOKEN]], 0.0)]\n",
+    "\n",
+    "        for _ in range(max_len):\n",
+    "            all_candidates = []\n",
+    "            for seq, score in sequences:\n",
+    "                if seq[-1] == token_to_idx[EOS_TOKEN]:\n",
+    "                    all_candidates.append((seq, score))\n",
+    "                    continue\n",
+    "                partial_smiles = ''.join([idx_to_token.get(idx, '') for idx in seq[1:]])\n",
+    "                if not is_valid_smiles_syntax(partial_smiles):\n",
+    "                    continue\n",
+    "                tgt_input = torch.tensor([seq], dtype=torch.long).to(device)\n",
+    "                tgt_mask = model.generate_square_subsequent_mask(len(seq)).to(device)\n",
+    "                outputs, valence_penalty = model.decoder(tgt_input, memory, substructure_pred, tgt_mask)\n",
+    "                log_probs = F.log_softmax(outputs[0, -1], dim=-1).cpu().numpy() - 0.1 * valence_penalty.cpu().numpy()\n",
+    "                # Boost stereochemistry tokens\n",
+    "                for tok in ['@', '/']:\n",
+    "                    if tok in token_to_idx:\n",
+    "                        log_probs[token_to_idx[tok]] += 0.5\n",
+    "                sorted_probs = np.sort(np.exp(log_probs))[::-1]\n",
+    "                cumulative_probs = np.cumsum(sorted_probs)\n",
+    "                cutoff_idx = np.searchsorted(cumulative_probs, nucleus_p)\n",
+    "                top_tokens = np.argsort(log_probs)[-cutoff_idx:] if cutoff_idx > 0 else np.argsort(log_probs)[-1:]\n",
+    "                top_probs = np.exp(log_probs[top_tokens]) / np.sum(np.exp(log_probs[top_tokens]))\n",
+    "                for tok in np.random.choice(top_tokens, size=min(beam_width, len(top_tokens)), p=top_probs):\n",
+    "                    new_smiles = partial_smiles + idx_to_token.get(int(tok), '')\n",
+    "                    if is_valid_smiles_syntax(new_smiles):\n",
+    "                        diversity_penalty = 0.2 * sum(1 for s, _ in sequences if tok in s[1:-1])\n",
+    "                        all_candidates.append((seq + [int(tok)], score + log_probs[tok] - diversity_penalty))\n",
+    "            sequences = sorted(all_candidates, key=lambda x: x[1], reverse=True)[:beam_width]\n",
+    "            if all(seq[-1] == token_to_idx[EOS_TOKEN] for seq, _ in sequences):\n",
+    "                break\n",
+    "\n",
+    "        results = []\n",
+    "        for seq, score in sequences:\n",
+    "            smiles = ''.join([idx_to_token.get(idx, '') for idx in seq[1:-1]])\n",
+    "            try:\n",
+    "                mol = Chem.MolFromSmiles(smiles, sanitize=True)\n",
+    "                if mol and is_plausible_molecule(smiles, true_mol):\n",
+    "                    smiles = Chem.MolToSmiles(mol, canonical=True, doRandom=True)\n",
+    "                    confidence = np.exp(score / len(seq))\n",
+    "                    results.append((smiles, confidence))\n",
+    "            except:\n",
+    "                continue\n",
+    "        return results if results else [(\"Invalid SMILES\", 0.0)]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualization Functions\n",
+    "def plot_attention_weights(attn_weights, title=\"Transformer Attention Weights\"):\n",
+    "    plt.figure(figsize=(10, 8))\n",
+    "    plt.imshow(attn_weights.squeeze().cpu().numpy(), cmap='viridis')\n",
+    "    plt.colorbar()\n",
+    "    plt.title(title)\n",
+    "    plt.xlabel(\"Key Tokens\")\n",
+    "    plt.ylabel(\"Query Tokens\")\n",
+    "    plt.show()\n",
+    "\n",
+    "def plot_gnn_edge_weights(edge_weights, edge_index, title=\"GNN Edge Importance\"):\n",
+    "    edge_scores = edge_weights[-1].cpu().numpy()\n",
+    "    plt.figure(figsize=(10, 8))\n",
+    "    plt.hist(edge_scores, bins=50)\n",
+    "    plt.title(title)\n",
+    "    plt.xlabel(\"Edge Weight Magnitude\")\n",
+    "    plt.ylabel(\"Frequency\")\n",
+    "    plt.show()\n",
+    "\n",
+    "# Error Analysis\n",
+    "def error_analysis(pred_smiles_list, true_smiles_list, adducts, precomputed_fps):\n",
+    "    errors = {'small': 0, 'large': 0, 'aromatic': 0, 'aliphatic': 0}\n",
+    "    adduct_errors = {adduct: [] for adduct in adduct_types}\n",
+    "    for pred_smiles, true_smiles, adduct in zip(pred_smiles_list, true_smiles_list, adducts):\n",
+    "        tanimoto = tanimoto_similarity(pred_smiles, true_smiles, precomputed_fps)\n",
+    "        if tanimoto < 0.3:\n",
+    "            mol = Chem.MolFromSmiles(true_smiles)\n",
+    "            if mol:\n",
+    "                mw = Descriptors.MolWt(mol)\n",
+    "                is_aromatic = any(atom.GetIsAromatic() for atom in mol.GetAtoms())\n",
+    "                errors['small' if mw < 300 else 'large'] += 1\n",
+    "                errors['aromatic' if is_aromatic else 'aliphatic'] += 1\n",
+    "                adduct_errors[adduct].append(tanimoto)\n",
+    "    print(\"Error Analysis:\")\n",
+    "    print(f\"Small molecules (<300 Da) errors: {errors['small']}\")\n",
+    "    print(f\"Large molecules (≥300 Da) errors: {errors['large']}\")\n",
+    "    print(f\"Aromatic molecule errors: {errors['aromatic']}\")\n",
+    "    print(f\"Aliphatic molecule errors: {errors['aliphatic']}\")\n",
+    "    for adduct, scores in adduct_errors.items():\n",
+    "        if scores:\n",
+    "            print(f\"Adduct {adduct} - Avg Tanimoto: {np.mean(scores):.4f}, Count: {len(scores)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hyperparameter Tuning\n",
+    "def objective(trial, train_data, val_data):\n",
+    "    lr = trial.suggest_float('lr', 1e-5, 1e-3, log=True)\n",
+    "    train_dataset = MSMSDataset(train_data, max_len=SUPERVISED_MAX_LEN, is_ssl=False)\n",
+    "    val_dataset = MSMSDataset(val_data, max_len=SUPERVISED_MAX_LEN, is_ssl=False)\n",
+    "    train_loader = DataLoader(train_dataset, batch_size=32, shuffle=True, num_workers=2)\n",
+    "    val_loader = DataLoader(val_dataset, batch_size=32, num_workers=2)\n",
+    "    model = MSMS2SmilesHybrid(vocab_size=vocab_size, d_model=768, nhead=12, num_layers=8, dim_feedforward=2048, dropout=0.2, fp_size=2048).to(device)\n",
+    "    return supervised_train(model, train_loader, val_loader, epochs=10, lr=lr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'graph_data'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "File \u001b[0;32m~/miniconda3/envs/naturems/lib/python3.10/site-packages/pandas/core/indexes/base.py:3812\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3811\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m-> 3812\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_engine\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcasted_key\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   3813\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
+      "File \u001b[0;32mpandas/_libs/index.pyx:167\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/index.pyx:196\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:7088\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:7096\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'graph_data'",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[20], line 6\u001b[0m\n\u001b[1;32m      3\u001b[0m kf \u001b[38;5;241m=\u001b[39m KFold(n_splits\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m5\u001b[39m, shuffle\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m, random_state\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m42\u001b[39m)\n\u001b[1;32m      4\u001b[0m fold_results \u001b[38;5;241m=\u001b[39m []\n\u001b[0;32m----> 6\u001b[0m external_dataset \u001b[38;5;241m=\u001b[39m \u001b[43mMSMSDataset\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdf_external\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmax_len\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mSUPERVISED_MAX_LEN\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mis_ssl\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[1;32m      7\u001b[0m external_loader \u001b[38;5;241m=\u001b[39m DataLoader(external_dataset, batch_size\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m32\u001b[39m, num_workers\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m)\n\u001b[1;32m      9\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m fold, (train_idx, val_idx) \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(kf\u001b[38;5;241m.\u001b[39msplit(df_massspecgym)):\n",
+      "Cell \u001b[0;32mIn[6], line 5\u001b[0m, in \u001b[0;36mMSMSDataset.__init__\u001b[0;34m(self, dataframe, max_len, is_ssl)\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, dataframe, max_len\u001b[38;5;241m=\u001b[39mPRETRAIN_MAX_LEN, is_ssl\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m):\n\u001b[1;32m      4\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mspectra \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mstack(dataframe[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mbinned\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39mvalues)\n\u001b[0;32m----> 5\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mgraph_data \u001b[38;5;241m=\u001b[39m \u001b[43mdataframe\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mgraph_data\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[38;5;241m.\u001b[39mvalues\n\u001b[1;32m      6\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mion_modes \u001b[38;5;241m=\u001b[39m dataframe[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mion_mode\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39mvalues\n\u001b[1;32m      7\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprecursor_bins \u001b[38;5;241m=\u001b[39m dataframe[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mprecursor_bin\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39mvalues\n",
+      "File \u001b[0;32m~/miniconda3/envs/naturems/lib/python3.10/site-packages/pandas/core/frame.py:4107\u001b[0m, in \u001b[0;36mDataFrame.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   4105\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcolumns\u001b[38;5;241m.\u001b[39mnlevels \u001b[38;5;241m>\u001b[39m \u001b[38;5;241m1\u001b[39m:\n\u001b[1;32m   4106\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_getitem_multilevel(key)\n\u001b[0;32m-> 4107\u001b[0m indexer \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcolumns\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   4108\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m is_integer(indexer):\n\u001b[1;32m   4109\u001b[0m     indexer \u001b[38;5;241m=\u001b[39m [indexer]\n",
+      "File \u001b[0;32m~/miniconda3/envs/naturems/lib/python3.10/site-packages/pandas/core/indexes/base.py:3819\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3814\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(casted_key, \u001b[38;5;28mslice\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m (\n\u001b[1;32m   3815\u001b[0m         \u001b[38;5;28misinstance\u001b[39m(casted_key, abc\u001b[38;5;241m.\u001b[39mIterable)\n\u001b[1;32m   3816\u001b[0m         \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28many\u001b[39m(\u001b[38;5;28misinstance\u001b[39m(x, \u001b[38;5;28mslice\u001b[39m) \u001b[38;5;28;01mfor\u001b[39;00m x \u001b[38;5;129;01min\u001b[39;00m casted_key)\n\u001b[1;32m   3817\u001b[0m     ):\n\u001b[1;32m   3818\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m InvalidIndexError(key)\n\u001b[0;32m-> 3819\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01merr\u001b[39;00m\n\u001b[1;32m   3820\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m:\n\u001b[1;32m   3821\u001b[0m     \u001b[38;5;66;03m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[1;32m   3822\u001b[0m     \u001b[38;5;66;03m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[1;32m   3823\u001b[0m     \u001b[38;5;66;03m#  the TypeError.\u001b[39;00m\n\u001b[1;32m   3824\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_check_indexing_error(key)\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'graph_data'"
+     ]
+    }
+   ],
+   "source": [
+    "# Cross-Validation and Training\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "kf = KFold(n_splits=5, shuffle=True, random_state=42)\n",
+    "fold_results = []\n",
+    "\n",
+    "external_dataset = MSMSDataset(df_external, max_len=SUPERVISED_MAX_LEN, is_ssl=False)\n",
+    "external_loader = DataLoader(external_dataset, batch_size=32, num_workers=2)\n",
+    "\n",
+    "for fold, (train_idx, val_idx) in enumerate(kf.split(df_massspecgym)):\n",
+    "    print(f\"\\nFold {fold+1}/5\")\n",
+    "    train_data = df_massspecgym.iloc[train_idx]\n",
+    "    val_data = df_massspecgym.iloc[val_idx]\n",
+    "    ssl_data = train_data.sample(frac=0.3, random_state=42)\n",
+    "\n",
+    "    train_dataset = MSMSDataset(train_data, max_len=SUPERVISED_MAX_LEN, is_ssl=False)\n",
+    "    val_dataset = MSMSDataset(val_data, max_len=SUPERVISED_MAX_LEN, is_ssl=False)\n",
+    "    ssl_dataset = MSMSDataset(ssl_data, max_len=PRETRAIN_MAX_LEN, is_ssl=True)\n",
+    "    train_loader = DataLoader(train_dataset, batch_size=32, shuffle=True, num_workers=2)\n",
+    "    val_loader = DataLoader(val_dataset, batch_size=32, num_workers=2)\n",
+    "    ssl_loader = DataLoader(ssl_dataset, batch_size=128, shuffle=True, num_workers=2)\n",
+    "\n",
+    "    # Hyperparameter tuning\n",
+    "    study = optuna.create_study(direction='minimize')\n",
+    "    study.optimize(lambda trial: objective(trial, train_data, val_data), n_trials=10)\n",
+    "    best_lr = study.best_params['lr']\n",
+    "    print(f\"Best learning rate for fold {fold+1}: {best_lr:.6f}\")\n",
+    "\n",
+    "    # Initialize and train model\n",
+    "    model = MSMS2SmilesHybrid(vocab_size=vocab_size, d_model=768, nhead=12, num_layers=8, dim_feedforward=2048, dropout=0.2, fp_size=2048).to(device)\n",
+    "    print(f\"Starting SSL pretraining for fold {fold+1}...\")\n",
+    "    ssl_pretrain(model, ssl_loader, epochs=3, lr=best_lr)\n",
+    "    print(f\"Starting supervised training for fold {fold+1}...\")\n",
+    "    best_val_loss = supervised_train(model, train_loader, val_loader, epochs=30, lr=best_lr, patience=5)\n",
+    "    fold_results.append(best_val_loss)\n",
+    "    torch.save({\n",
+    "        'model_state_dict': model.state_dict(),\n",
+    "        'token_to_idx': token_to_idx,\n",
+    "        'idx_to_token': idx_to_token\n",
+    "    }, f'best_msms_hybrid_fold_{fold+1}.pt')\n",
+    "\n",
+    "print(f\"Cross-validation results: {fold_results}\")\n",
+    "print(f\"Average validation loss: {np.mean(fold_results):.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "SIAnnRuExQUs"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "# External Dataset Evaluation\n",
+    "model.eval()\n",
+    "external_metrics = {'tanimoto': [], 'dice': [], 'mcs': [], 'mw_diff': [], 'logp_diff': [], 'substructure': []}\n",
+    "pred_smiles_list = []\n",
+    "true_smiles_list = []\n",
+    "adducts_list = []\n",
+    "num_samples = min(5, len(external_dataset))\n",
+    "\n",
+    "for sample_idx in range(num_samples):\n",
+    "    sample_spectrum = external_dataset[sample_idx][0]\n",
+    "    sample_graph = external_dataset[sample_idx][1]\n",
+    "    sample_ion_mode = external_dataset[sample_idx][3]\n",
+    "    sample_precursor_bin = external_dataset[sample_idx][4]\n",
+    "    sample_adduct_idx = external_dataset[sample_idx][5]\n",
+    "    true_smiles = external_dataset[sample_idx][6]\n",
+    "\n",
+    "    predicted_results = beam_search(model, sample_spectrum, sample_graph, sample_ion_mode, sample_precursor_bin, sample_adduct_idx, true_smiles, beam_width=10, max_len=SUPERVISED_MAX_LEN, device=device)\n",
+    "    pred_smiles_list.extend([smiles for smiles, _ in predicted_results])\n",
+    "    true_smiles_list.extend([true_smiles] * len(predicted_results))\n",
+    "    adducts_list.extend([df_external.iloc[sample_idx]['adduct']] * len(predicted_results))\n",
+    "\n",
+    "    print(f\"\\nExternal Sample {sample_idx} - True SMILES: {true_smiles}\")\n",
+    "    print(\"Top Predicted SMILES:\")\n",
+    "    for smiles, confidence in predicted_results[:3]:\n",
+    "        external_metrics['tanimoto'].append(tanimoto_similarity(smiles, true_smiles, all_fingerprints))\n",
+    "        external_metrics['dice'].append(dice_similarity(smiles, true_smiles))\n",
+    "        external_metrics['mcs'].append(mcs_similarity(smiles, true_smiles))\n",
+    "        external_metrics['mw_diff'].append(mw_difference(smiles, true_smiles))\n",
+    "        external_metrics['logp_diff'].append(logp_difference(smiles, true_smiles))\n",
+    "        external_metrics['substructure'].append(substructure_match(smiles, true_smiles, model.gnn_encoder.substructures))\n",
+    "        print(f\"SMILES: {smiles}, Confidence: {confidence:.4f}, Tanimoto: {external_metrics['tanimoto'][-1]:.4f}, Dice: {external_metrics['dice'][-1]:.4f}, MCS: {external_metrics['mcs'][-1]:.4f}\")\n",
+    "        if len(smiles) > 100 and smiles.count('C') > len(smiles) * 0.8:\n",
+    "            print(\"Warning: Predicted SMILES is a long carbon chain, indicating potential model underfitting.\")\n",
+    "        if smiles != \"Invalid SMILES\":\n",
+    "            mol = Chem.MolFromSmiles(smiles, sanitize=True)\n",
+    "            if mol:\n",
+    "                print(f\"Molecular Weight: {Descriptors.MolWt(mol):.2f}, LogP: {Descriptors.MolLogP(mol):.2f}\")\n",
+    "\n",
+    "    # Visualize molecules\n",
+    "    if predicted_results[0][0] != \"Invalid SMILES\":\n",
+    "        pred_mol = Chem.MolFromSmiles(predicted_results[0][0], sanitize=True)\n",
+    "        true_mol = Chem.MolFromSmiles(true_smiles, sanitize=True)\n",
+    "        if pred_mol and true_mol:\n",
+    "            img = Draw.MolsToGridImage([true_mol, pred_mol], molsPerRow=2, subImgSize=(300, 300), legends=['True', 'Predicted'])\n",
+    "            img_array = np.array(img.convert('RGB'))\n",
+    "            plt.figure(figsize=(10, 5))\n",
+    "            plt.imshow(img_array)\n",
+    "            plt.axis('off')\n",
+    "            plt.title(f\"External Sample {sample_idx} - Tanimoto: {external_metrics['tanimoto'][0]:.4f}\")\n",
+    "            plt.show()\n",
+    "\n",
+    "    # Visualize attention and GNN weights for first sample\n",
+    "    if sample_idx == 0:\n",
+    "        with torch.no_grad():\n",
+    "            spectrum = sample_spectrum.unsqueeze(0).to(device)\n",
+    "            graph_data = Batch.from_data_list([sample_graph]).to(device)\n",
+    "            ion_mode_idx = torch.tensor([sample_ion_mode], dtype=torch.long).to(device)\n",
+    "            precursor_idx = torch.tensor([sample_precursor_bin], dtype=torch.long).to(device)\n",
+    "            adduct_idx = torch.tensor([sample_adduct_idx], dtype=torch.long).to(device)\n",
+    "            _, attn_weights = model.transformer_encoder(spectrum, ion_mode_idx, precursor_idx, adduct_idx)\n",
+    "            _, _, edge_weights = model.gnn_encoder(graph_data, ion_mode_idx, precursor_idx, adduct_idx)\n",
+    "            plot_attention_weights(attn_weights, title=f\"External Fold Transformer Attention Weights\")\n",
+    "            plot_gnn_edge_weights(edge_weights, sample_graph.edge_index, title=f\"External Fold GNN Edge Importance\")\n",
+    "\n",
+    "# Final Evaluation\n",
+    "print(f\"External Validity Rate: {validity_rate(pred_smiles_list):.2f}%\")\n",
+    "print(f\"External Prediction Diversity: {prediction_diversity(pred_smiles_list):.4f}\")\n",
+    "print(\"External Metrics Summary:\")\n",
+    "print(f\"Avg Tanimoto: {np.mean(external_metrics['tanimoto']):.4f}\")\n",
+    "print(f\"Avg Dice: {np.mean(external_metrics['dice']):.4f}\")\n",
+    "print(f\"Avg MCS: {np.mean(external_metrics['mcs']):.4f}\")\n",
+    "print(f\"Avg MW Difference: {np.mean([x for x in external_metrics['mw_diff'] if x != float('inf')]):.2f}\")\n",
+    "print(f\"Avg LogP Difference: {np.mean([x for x in external_metrics['logp_diff'] if x != float('inf')]):.2f}\")\n",
+    "print(f\"Avg Substructure Match: {np.mean(external_metrics['substructure']):.4f}\")\n",
+    "error_analysis(pred_smiles_list, true_smiles_list, adducts_list, all_fingerprints)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python (naturems)",
+   "language": "python",
+   "name": "naturems"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This notebook (`notebook-for-pc.ipynb`) is a modular and memory-optimized version of `v1.ipynb`. It is designed for running on high-end local PCs with ample RAM and disk space.

### Key Features:
- Breaks down and restructures the original `v1.ipynb` for better readability and modularity.
- Identifies and isolates memory-intensive steps for better debugging and performance profiling.
- Suitable for iterative testing, optimization, and extension on resource-rich machines.
- Keeps all logic from `v1` intact — imports, data loading, augmentation, spectrum binning, graph construction, and model definition are preserved.

No existing files were modified. This is a standalone notebook added to support experimentation and refinement of the MS/MS to SMILES pipeline.

